### PR TITLE
Dependencies installation for Fedora

### DIFF
--- a/README
+++ b/README
@@ -60,34 +60,11 @@ from the folder or setup visual studio to use the desura-d.exe from the build_ou
 Build Desura Linux
 ===================
 
-Need to have gcc 4.5 installed and these deps:
- * git-core   
- * subversion
- * m4
- * build-essential
- * binutils
- * automake
- * autoconf
- * libtool
- * libgtk2.0-dev 
- * libnss3-dev 
- * libgconf2-dev 
- * libgnome-keyring-dev 
- * libdbus-glib-1-dev 
- * gperf 
- * bison 
- * libcups2-dev 
- * flex 
- * libjpeg-dev 
- * libasound2-dev 
- * libbz2-dev 
- * libxpm-dev 
- * libx11-dev 
- * libssl-dev 
- * scons
-
-To install all of this deps on Debian/Ubuntu just invoke command:
+To install all of buil deps on Debian/Ubuntu just invoke this command as root:
 apt-get install gcc-4.5 git-core subversion m4 build-essential binutils automake autoconf libtool libgtk2.0-dev libnss3-dev libgconf2-dev libgnome-keyring-dev libdbus-glib-1-dev gperf bison libcups2-dev flex libjpeg-dev libasound2-dev libbz2-dev libxpm-dev libx11-dev libssl-dev scons
+
+Or if you are using Fedora invoke this command as root:
+yum install git subversion m4 autoconf gcc-c++ glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel scons
 
 Check out repo
 Copy branding_default in src to src/branding
@@ -146,4 +123,3 @@ Run Linux
 ===================
 
 If you built the debug build (default) you should be able to run ./test.sh in the build_lin folder to teset or ./desura in the build_out/debug_lin folder
-

--- a/README
+++ b/README
@@ -60,7 +60,7 @@ from the folder or setup visual studio to use the desura-d.exe from the build_ou
 Build Desura Linux
 ===================
 
-To install all of buil deps on Debian/Ubuntu just invoke this command as root:
+To install all of build deps on Debian/Ubuntu just invoke this command as root:
 apt-get install gcc-4.5 git-core subversion m4 build-essential binutils automake autoconf libtool libgtk2.0-dev libnss3-dev libgconf2-dev libgnome-keyring-dev libdbus-glib-1-dev gperf bison libcups2-dev flex libjpeg-dev libasound2-dev libbz2-dev libxpm-dev libx11-dev libssl-dev scons
 
 Or if you are using Fedora invoke this command as root:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,1 +1,20 @@
-apt-get install gcc-4.5 git-core subversion m4 build-essential binutils automake autoconf libtool libgtk2.0-dev libnss3-dev libgconf2-dev libgnome-keyring-dev libdbus-glib-1-dev gperf bison libcups2-dev flex libjpeg-dev libasound2-dev libbz2-dev libxpm-dev libx11-dev libssl-dev scons
+#!/bin/sh
+# Determine the Linux distribution that is being run and install the build dependencies for it.
+
+PASS_MESSAGE="Please provide root password to install build dependecies"
+
+if [ -f /etc/SuSE-release ]; then
+	DISTRIBUTION="suse"
+elif [ -f /etc/debian_version ]; then
+	DISTRIBUTION="debian"
+	if [ "$(whoami)" != 'root' ]; then
+		echo $PASS_MESSAGE
+	fi
+	su -c 'apt-get install gcc-4.5 git-core subversion m4 build-essential binutils automake autoconf libtool libgtk2.0-dev libnss3-dev libgconf2-dev libgnome-keyring-dev libdbus-glib-1-dev gperf bison libcups2-dev flex libjpeg-dev libasound2-dev libbz2-dev libxpm-dev libx11-dev libssl-dev scons'
+elif [ -f /etc/redhat-release ]; then
+	DISTRIBUTION="redhat"
+	if [ "$(whoami)" != 'root' ]; then
+		echo $PASS_MESSAGE
+	fi
+	su -c 'yum install git subversion m4 autoconf gcc-c++ glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel scons'
+fi


### PR DESCRIPTION
Install-deps.sh now determines running distribution and runs corresponding installation command. For now support is limited to Debian-based and Fedora.
