### PR TITLE
fix install-deps.sh for arch linux

### DIFF
--- a/README
+++ b/README
@@ -125,4 +125,4 @@ cd build_lin
 Run Linux
 ===================
 
-If you built the debug build (default) you should be able to run ./test.sh in the build_lin folder to teset or ./desura in the build_out/debug_lin folder
+If you built the debug build (default) you should be able to run ./test.sh in the build_lin folder to test or ./desura in the build_out/debug_lin folder

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -28,8 +28,7 @@ elif [ -f /etc/arch-release ]; then
 	if [ "$(whoami)" != 'root' ]; then
 		echo $PASS_MESSAGE
 	fi
-	DEPS="$(pacman -T git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify)"
-	su -c 'pacman -S $DEPS'
+	su -c 'pacman -S --needed   git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify'
 elif [ -f /etc/slackware-version ]; then
 	DISTRIBUTION="Slackware"
 fi

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -28,7 +28,15 @@ elif [ -f /etc/arch-release ]; then
 	if [ "$(whoami)" != 'root' ]; then
 		echo $PASS_MESSAGE
 	fi
-	su -c 'pacman -S --needed   git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify'
+	DEPS=`pacman -T git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify`
+	echo ${DEPS} > /tmp/desura_deps.txt
+	if [ `cat /tmp/desura_deps.txt | wc -c` = "1" ] ; then
+		echo "Dependencies are already installed."
+	else
+		DEPS=`echo ${DEPS}`
+		echo "Dependencies missing: ${DEPS}"
+		su -c 'pacman -S --asdeps `cat /tmp/desura_deps.txt`'
+	fi
 elif [ -f /etc/slackware-version ]; then
 	DISTRIBUTION="Slackware"
 fi


### PR DESCRIPTION
Tested with the package "scons":
Before, I got "error: no targets specified (use -h for help)" after entering the password regardless "scons" being installed or not.
The new implementation removes the DEPS var (for arch) and processes the dependencies with "pacman -S --needed".
