### PR TITLE
Quote $DISTRIBUTION in install.sh for grep

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -34,7 +34,7 @@ elif [ -f /etc/slackware-version ]; then
 	DISTRIBUTION="Slackware"
 fi
 
-echo $UNSUPPORTED_DISTROS| grep -q $DISTRIBUTION
+echo $UNSUPPORTED_DISTROS| grep -q "$DISTRIBUTION"
 if [ $? -eq 0 ];then
   echo $DISTRIBUTION $UNSUPPORTED_MESSAGE
 fi


### PR DESCRIPTION
Some Distros have a space in them, specifically Red Hat.
On a Red Hat distro install.sh will output the following
error when checking for Unknown distro:
grep: Hat: No such file or directory
