### PR TITLE
Modified install-deps for ArchLinux, made the script less complicated

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -11,14 +11,7 @@ if [ -f /etc/debian_version ]; then
 elif [ -f /etc/redhat-release ]; then
 	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs
 elif [ -f /etc/arch-release ]; then
-	DEPS="$(pacman -T git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify)"
-	DEPS="$(echo $DEPS | sed -e 's/\n/ /g')"
-	
-	if [ "$DEPS" == "" ]; then
-		echo "Dependencies already installed."
-	else
-		pacman -S --asdeps $DEPS
-	fi
+	pacman -S --asdeps --needed git subversion m4 autoconf gcc glibc binutils autoconf libtool gtk2 nss libgnome-keyring dbus-glib gperf bison cups flex libjpeg-turbo alsa-lib bzip2 libxpm libx11 openssl scons gconf libnotify
 else
   echo "Unsupported operating system."
 fi


### PR DESCRIPTION
For ArchLinux, install-deps.sh made a list of dependencies, for queried which one where installed, then built a second list of packages, and called pacman with that list as an argument.

pacman can handle this itself, just using the "--needed" flag; it'll install required packages, and leave those present as they are.

This is just a simple change that removes unnecesary code, and it's quite cleaner _not_ to parse the output of pacman; the format can change at any time.
