### PR TITLE
Update To Branding Template licence.txt

### DIFF
--- a/src/branding_desurium/sources/licence.txt
+++ b/src/branding_desurium/sources/licence.txt
@@ -1,4 +1,4 @@
-"Desubot" logo design created by Notshi for the Desurium project and released under the CC0 1.0 Universal Public Domain Dedication as described below.
+"Desubot" logo design created by shi for the Desurium project and released under the CC0 1.0 Universal Public Domain Dedication as described below.
 SVG and XCF templates provided by Cheeseness (Josh Bush) and released under the CC0 1.0 Universal Public Domain Dedication as described below.
 
 Creative Commons Legal Code


### PR DESCRIPTION
As requested by Notshi via email I've changed "Notshi" to "shi" in the licence.txt file that accompanies the Desurium branding template files.
