### PR TITLE
Clang

### DIFF
--- a/src/include/util/gcString.h
+++ b/src/include/util/gcString.h
@@ -1161,7 +1161,7 @@ public:
 	{
 		std::basic_string<T> out;
 		Template::ConvertStdString(str.c_str(), out);
-		assign(out);
+		std::basic_string<T>::assign(out);
 	}
 
 	template<typename CT>
@@ -1172,7 +1172,7 @@ public:
 
 		std::basic_string<T> out;
 		Template::ConvertStdString(str, out);
-		assign(out);
+		std::basic_string<T>::assign(out);
 	}
 
 	template <typename CT, typename A>
@@ -1180,7 +1180,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		std::basic_string<T>assign(Template::Format<T, A, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B>
@@ -1188,7 +1188,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, B, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		std::basic_string<T>::assign(Template::Format<T, A, B, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C>
@@ -1196,7 +1196,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, B, C, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		std::basic_string<T>::assign(Template::Format<T, A, B, C, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D>
@@ -1204,7 +1204,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, B, C, D, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, d, Template::NullArg(), Template::NullArg()));
+		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, d, Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D, typename E>
@@ -1212,7 +1212,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, B, C, D, E, Template::NullArg>(t.c_str(), a, b, c, d, e, Template::NullArg()));
+		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, E, Template::NullArg>(t.c_str(), a, b, c, d, e, Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D, typename E, typename F>
@@ -1220,7 +1220,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		assign(Template::Format<T, A, B, C, D, E, F>(t.c_str(), a, b, c, d, e, f));
+		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, E, F>(t.c_str(), a, b, c, d, e, f));
 	}
 
 
@@ -1228,7 +1228,7 @@ public:
 	{
 		if (!szFormat)
 		{
-			assign(gcBaseString<T>());
+			std::basic_string<T>::assign(gcBaseString<T>());
 			return;
 		}
 

--- a/src/include/util/gcString.h
+++ b/src/include/util/gcString.h
@@ -1161,7 +1161,7 @@ public:
 	{
 		std::basic_string<T> out;
 		Template::ConvertStdString(str.c_str(), out);
-		std::basic_string<T>::assign(out);
+		this->assign(out);
 	}
 
 	template<typename CT>
@@ -1172,7 +1172,7 @@ public:
 
 		std::basic_string<T> out;
 		Template::ConvertStdString(str, out);
-		std::basic_string<T>::assign(out);
+		this->assign(out);
 	}
 
 	template <typename CT, typename A>
@@ -1180,7 +1180,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>assign(Template::Format<T, A, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		this->assign(Template::Format<T, A, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B>
@@ -1188,7 +1188,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>::assign(Template::Format<T, A, B, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		this->assign(Template::Format<T, A, B, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, Template::NullArg(), Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C>
@@ -1196,7 +1196,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>::assign(Template::Format<T, A, B, C, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, Template::NullArg(), Template::NullArg(), Template::NullArg()));
+		this->assign(Template::Format<T, A, B, C, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, Template::NullArg(), Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D>
@@ -1204,7 +1204,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, d, Template::NullArg(), Template::NullArg()));
+		this->assign(Template::Format<T, A, B, C, D, Template::NullArg, Template::NullArg>(t.c_str(), a, b, c, d, Template::NullArg(), Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D, typename E>
@@ -1212,7 +1212,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, E, Template::NullArg>(t.c_str(), a, b, c, d, e, Template::NullArg()));
+		this->assign(Template::Format<T, A, B, C, D, E, Template::NullArg>(t.c_str(), a, b, c, d, e, Template::NullArg()));
 	}
 
 	template <typename CT, typename A, typename B, typename C, typename D, typename E, typename F>
@@ -1220,7 +1220,7 @@ public:
 	{
 		std::basic_string<T> t;
 		Template::ConvertStdString(tIn, t);
-		std::basic_string<T>::assign(Template::Format<T, A, B, C, D, E, F>(t.c_str(), a, b, c, d, e, f));
+		this->assign(Template::Format<T, A, B, C, D, E, F>(t.c_str(), a, b, c, d, e, f));
 	}
 
 
@@ -1228,7 +1228,7 @@ public:
 	{
 		if (!szFormat)
 		{
-			std::basic_string<T>::assign(gcBaseString<T>());
+			assign(gcBaseString<T>());
 			return;
 		}
 


### PR DESCRIPTION
important for #104

will fix this error while building with clang:

```
In file included from /home/karol/Dokumente/repos/Desurium/src/common/gcJSBase.cpp:12:
In file included from /home/karol/Dokumente/repos/Desurium/src/common/Common.h:540:
In file included from /home/karol/Dokumente/repos/Desurium/src/include/util/UtilString.h:26:
/home/karol/Dokumente/repos/Desurium/src/include/util/gcString.h:1183:3: error: use of undeclared identifier 'assign'
                assign(Template::Format<T, A, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg, Template::NullArg>(t.c_str(), a, Template::NullArg(), Template::NullArg(), ...
                ^
/home/karol/Dokumente/repos/Desurium/src/common/gcJSBase.cpp:205:13: note: in instantiation of function template specialization 'gcBaseString<char>::gcBaseString<wchar_t, const char *>' requested here
        m_szName = gcString(L"Desura/{0}", name);
                   ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1057:7: note: must qualify identifier to find this declaration in dependent base class
      assign(const basic_string& __str);
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1069:7: note: must qualify identifier to find this declaration in dependent base class
      assign(basic_string&& __str)
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1089:7: note: must qualify identifier to find this declaration in dependent base class
      assign(const basic_string& __str, size_type __pos, size_type __n)
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1105:7: note: must qualify identifier to find this declaration in dependent base class
      assign(const _CharT* __s, size_type __n);
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1117:7: note: must qualify identifier to find this declaration in dependent base class
      assign(const _CharT* __s)
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1133:7: note: must qualify identifier to find this declaration in dependent base class
      assign(size_type __n, _CharT __c)
      ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1146:9: note: must qualify identifier to find this declaration in dependent base class
        assign(_InputIterator __first, _InputIterator __last)
        ^
/usr/bin/../lib/gcc/x86_64-pc-linux-gnu/4.6.2/include/g++-v4/bits/basic_string.h:1156:7: note: must qualify identifier to find this declaration in dependent base class
      assign(initializer_list<_CharT> __l)
      ^
```
