### PR TITLE
Added required dependencies for building on Fedora

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -19,10 +19,10 @@ if [ -f /etc/debian_version ]; then # Debian  (untested!)
     if [ "${MUST_BE_INSTALLED}" != "" ] ; then
         apt-get install ${MUST_BE_INSTALLED}
     else
-        echo "everything intalled"
+        echo "everything installed"
     fi
 elif [ -f /etc/redhat-release ]; then
-	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel
+	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel libxslt-devel yasm-devel libevent-devel libwebp-devel
 elif [ -f /etc/arch-release ]; then
 	echo -e "\e[1;31mArch Linux detected!\e[0m"
 	echo -e "\e[1;31mNote: there is a pkgbuild in ./distro/archlinux/\e[0m"


### PR DESCRIPTION
I added the packages libxslt-devel yasm-devel libevent-devel and libwebp-devel to the redhat-release section, in the install-deps.sh file.
These were added as I built Desurium, and found out which packages were missing.
