### PR TITLE
getCmdStdOut now reads from popen correctly

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -22,7 +22,7 @@ if [ -f /etc/debian_version ]; then # Debian  (untested!)
         echo "everything installed"
     fi
 elif [ -f /etc/redhat-release ]; then
-	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel libxslt-devel yasm-devel libevent-devel libwebp-devel
+	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel libxslt-devel yasm-devel libevent-devel libwebp-devel boost-devel
 elif [ -f /etc/arch-release ]; then
 	echo -e "\e[1;31mArch Linux detected!\e[0m"
 	echo -e "\e[1;31mNote: there is a pkgbuild in ./distro/archlinux/\e[0m"

--- a/src/static/util/code/UtilLinux.cpp
+++ b/src/static/util/code/UtilLinux.cpp
@@ -675,14 +675,39 @@ std::string getCmdStdout(const char* command, int stdErrDest)
 		ERROR_OUTPUT(gcString("Failed to run command: [{0}]\n", command).c_str());
 		return "";
 	}
+
+	// Get the size of fd
+	fseek (fd,0,SEEK_END);
+	long size = ftell(fd);
+	rewind(fd);
 	
-	char buffer[512];
-	std::string output;
+	char * buffer = (char*) malloc (sizeof(char)*size);
+	if(buffer == NULL) {
+		// Failed to allocated memory
+		ERROR_OUTPUT(gcString("Failed to allocate memory.").c_str());
+		return "";
+	}
+
+	size_t elemRead;
+	elemRead = fread(buffer,1,size,fd);
+	if(elemRead != size) {
+		// All elements were not read
+		if(feof(fd) != 0) {
+			// EOF indicator is set
+		}
+		if(ferror(fd) != 0) {
+			// ERROR indicator is set
+			ERROR_OUTPUT(gcString("Failed to read command result").c_str());
+		}
+	}
+
+	std::string output(buffer);
 	
-	while (fgets(buffer, 512, fd) != NULL)
-		output.append(buffer);
+	/*while (fgets(buffer, 512, fd) != NULL)
+		output.append(buffer);*/
 
 	pclose(fd);
+	free(buffer);
 	return trim(output); 
 }
 

--- a/src/tests/util/UtilLinux_test.cpp
+++ b/src/tests/util/UtilLinux_test.cpp
@@ -30,11 +30,11 @@ BOOST_AUTO_TEST_CASE (Util_Lin_String_Output)
 	std::wcout << L"UTIL::LIN::getDesktopPath(L\"test/path\") result: " << UTIL::LIN::getDesktopPath(L"test/path") << std::endl;
 
 	std::cout << "-- Testing UTIL::LIN::getOSString(...) --\n";
-	//std::cout << "UTIL::LIN::getOSString() result: " << UTIL::LIN::getOSString() << std::endl;
+	std::cout << "UTIL::LIN::getOSString() result: " << UTIL::LIN::getOSString() << std::endl;
 
 	std::cout << "-- Testing UTIL::LIN::getFreeSpace(...) --\n";
 	std::cout << "UTIL::LIN::getFreeSpace(\"/\") result: " << UTIL::LIN::getFreeSpace("/") << std::endl;
 
 	std::cout << "-- Testing UTIL::LIN::getCmdStdout(...) --\n";
-	//std::cout << "UTIL::LIN::getCmdStdout(\"ping -c 4\",0) result: " << UTIL::LIN::getCmdStdout("ping -c 4",0) << std::endl;
+	std::cout << "UTIL::LIN::getCmdStdout(\"xdg-user-dir DESKTOP\",0) result: " << UTIL::LIN::getCmdStdout("xdg-user-dir DESKTOP",0) << std::endl;
 }


### PR DESCRIPTION
The problem was that fgets was used to read before, although it is not designed to read binary data, so I used fread instead.
This fix also made getOSString() print correctly
