### PR TITLE
Added boost-static to install-deps.sh for RedHat based systems.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -22,7 +22,7 @@ if [ -f /etc/debian_version ]; then # Debian  (untested!)
         echo "everything installed"
     fi
 elif [ -f /etc/redhat-release ]; then
-	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel libxslt-devel yasm-devel libevent-devel libwebp-devel
+	yum install git subversion m4 autoconf gcc-c++ libstdc++-static glibc-devel binutils autoconf libtool gtk2-devel nss-devel GConf2-devel libgnome-keyring-devel dbus-glib-devel gperf bison cups-devel flex libjpeg-turbo-devel alsa-lib-devel bzip2-devel libXpm-devel libX11-devel openssl-devel libnotify-devel scons xdg-user-dirs v8-devel c-ares-devel sqlite-devel libxslt-devel yasm-devel libevent-devel libwebp-devel boost-devel boost-static 
 elif [ -f /etc/arch-release ]; then
 	echo -e "\e[1;31mArch Linux detected!\e[0m"
 	echo -e "\e[1;31mNote: there is a pkgbuild in ./distro/archlinux/\e[0m"


### PR DESCRIPTION
Under Fedora, the install script will throw the following error whilst checking dependencies unless boost-static is installed:
"The following Boost libraries could not be found: boost_test_exec_monitor"
