### PR TITLE
Update Debian related variables

### DIFF
--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -12,6 +12,7 @@ set(CPACK_SOURCE_GENERATOR "TBZ2;TGZ;ZIP")
 ###############################################################################
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Desura is a gaming client that allows users to one click download and install games and game modification.")
+set(CPACK_PACKAGE_HOMEPAGE "http://www.desura.com/")
 set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 8)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
@@ -31,10 +32,13 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${CPACK_PACKAGE_VERSION}")
 # deb specific values
 ###############################################################################
 
+set(CPACK_DEBIAN_PACKAGE_NAME "desurium")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Karol Herbst")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "flex gperf xdg-utils yasm")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev libboost-thread-dev libc-ares2 libjpeg62 libtinyxml-dev libwebp-dev")
+set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE}"
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
-set(CPACK_DEBIAN_PACKAGE_NAME "desura")
 
 ###############################################################################
 # rpm specific values

--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -37,7 +37,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Karol Herbst")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev libboost-thread-dev libc-ares2 libjpeg62 libtinyxml-dev libwebp-dev")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
-set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE}"
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE}")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
 
 ###############################################################################

--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -13,8 +13,8 @@ set(CPACK_SOURCE_GENERATOR "TBZ2;TGZ;ZIP")
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Desura is a gaming client that allows users to one click download and install games and game modification.")
 set(CPACK_PACKAGE_VERSION_MAJOR 0)
-set(CPACK_PACKAGE_VERSION_MINOR 8)
-set(CPACK_PACKAGE_VERSION_PATCH 0)
+set(CPACK_PACKAGE_VERSION_MINOR 0)
+set(CPACK_PACKAGE_VERSION_PATCH 1)
 
 ###############################################################################
 # some internal variables
@@ -32,14 +32,17 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${CPACK_PACKAGE_VERSION}")
 ###############################################################################
 
 set(CPACK_DEBIAN_PACKAGE_NAME "desurium")
-set(CPACK_DEBIAN_PACKAGE_VERSION "1:2012.06.11")
-set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "any")
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Karol Herbst") #email missing
+set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}")
+if(64BIT)
+ set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+else(64BIT)
+ set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
+endif(64BIT)
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Tomasz Makarewicz <makson96@gmail.com>")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev, libboost-thread-dev, libc-ares2, libjpeg62, libtinyxml-dev, libwebp-dev")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev, libboost-thread-dev, libc-ares2, libjpeg62, libtinyxml-dev")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
-
 
 ###############################################################################
 # rpm specific values

--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -12,7 +12,6 @@ set(CPACK_SOURCE_GENERATOR "TBZ2;TGZ;ZIP")
 ###############################################################################
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Desura is a gaming client that allows users to one click download and install games and game modification.")
-set(CPACK_PACKAGE_HOMEPAGE "http://www.desura.com/")
 set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 8)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
@@ -33,12 +32,14 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${CPACK_PACKAGE_VERSION}")
 ###############################################################################
 
 set(CPACK_DEBIAN_PACKAGE_NAME "desurium")
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Karol Herbst")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev libboost-thread-dev libc-ares2 libjpeg62 libtinyxml-dev libwebp-dev")
+set(CPACK_DEBIAN_PACKAGE_VERSION "1:2012.06.11")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "any")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Karol Herbst") #email missing
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev, libboost-thread-dev, libc-ares2, libjpeg62, libtinyxml-dev, libwebp-dev")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
-set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE}")
-set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
+
 
 ###############################################################################
 # rpm specific values


### PR DESCRIPTION
Few notes:
- in CPACK_DEBIAN_PACKAGE_MAINTAINER there is email address missing in "<>" marks.
- in CPACK_DEBIAN_PACKAGE_DEPENDS I needed to put some dev packages, because packages with standard libraries differ by names in different version of systems and I want to make it work on as many systems as possible (dev package will install standard library as a dependency).
- on Ubuntu Natty and Debian Squeeze and earlier versions there is no libwebp, so dependencies could not be satisfied.
