### PR TITLE
Fixed patch script error check on Windows.

### DIFF
--- a/cmake/scripts/Patch.bat
+++ b/cmake/scripts/Patch.bat
@@ -1,7 +1,7 @@
+@echo off
 patch -p0 -N -i %1
-echo %errorlevel% Error level
 
 REM if we hit one means the patch is all ready applied
 IF ["%errorlevel%"]==["1"] (
-	SET errorlevel=0
+	EXIT /B 0
 )


### PR DESCRIPTION
The ERRORLEVEL environment variable is read-only on Windows and thus
the check to adjust the error level when patches have already been applied
was not working correctly.  This change updated it to use EXIT /B to terminate
the script correctly.
