### PR TITLE
Fix for #223: Locally-installed entries are forced to "Not Installed" on restart

### DIFF
--- a/src/shared/usercore/code/ItemHandle_nix.cpp
+++ b/src/shared/usercore/code/ItemHandle_nix.cpp
@@ -127,7 +127,8 @@ void ItemHandle::doLaunch(bool useXdgOpen, const char* globalExe, const char* gl
 	UserCore::Item::BranchInfoI* branch = getItemInfo()->getCurrentBranch();
 
 #ifdef NIX64
-	if (!useXdgOpen && branch && branch->is32Bit())
+	// Branches can be marked simultaneously 32- and 64-bit, be sure it isn't.
+	if (!useXdgOpen && branch && !branch->is64Bit())
 	{
 		#ifdef USE_BITTEST
 			int testRet = system("desura_bittest");

--- a/src/shared/usercore/code/ItemInfo.cpp
+++ b/src/shared/usercore/code/ItemInfo.cpp
@@ -177,9 +177,12 @@ void ItemInfo::saveDb(sqlite3x::sqlite3_connection* db)
 		cmd.bind(9, (long long int)m_iId.toInt64()); //internal id
 		cmd.executenonquery();
 
-		for (size_t x=0; x<m_vBranchList.size(); x++)
-		{
-			m_vBranchList[x]->saveDb(db);
+		// Don't bother saving TYPE_LINKs, they don't have a proper BranchID anyway.
+		if(getId().getType() != DesuraId::TYPE_LINK) {
+			for (size_t x=0; x<m_vBranchList.size(); x++)
+			{
+				m_vBranchList[x]->saveDb(db);
+			}
 		}
 
 		std::for_each(m_mBranchInstallInfo.begin(), m_mBranchInstallInfo.end(), [&db](std::pair<uint32, BranchInstallInfo*> p)
@@ -225,9 +228,12 @@ void ItemInfo::saveDbFull(sqlite3x::sqlite3_connection* db)
 
 	cmd.executenonquery();
 
-	for (size_t x=0; x<m_vBranchList.size(); x++)
-	{
-		m_vBranchList[x]->saveDbFull(db);
+	// Don't bother saving TYPE_LINKs, they don't have a proper BranchID anyway.
+	if(getId().getType() != DesuraId::TYPE_LINK) {
+		for (size_t x=0; x<m_vBranchList.size(); x++)
+		{
+			m_vBranchList[x]->saveDbFull(db);
+		}
 	}
 
 	std::for_each(m_mBranchInstallInfo.begin(), m_mBranchInstallInfo.end(), [&db](std::pair<uint32, BranchInstallInfo*> p)

--- a/src/shared/usercore/code/ItemInfo.cpp
+++ b/src/shared/usercore/code/ItemInfo.cpp
@@ -356,15 +356,7 @@ void ItemInfo::loadDb(sqlite3x::sqlite3_connection* db)
 
 		// A TYPE_LINK may or may not have branches stored on disk, but will need one at runtime.
 		if(getId().getType() == DesuraId::TYPE_LINK && m_vBranchList.size() == 0) {
-#ifdef WIN32
-			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[100]);
-#else
-#ifdef NIX64
-			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[120]);
-#else
-			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[110]);
-#endif
-#endif
+			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[BUILDID_PUBLIC]);
 			bi->setLinkInfo(getName());
 			m_vBranchList.push_back(bi);
 			m_INBranchIndex = 0;
@@ -1249,20 +1241,10 @@ void ItemInfo::setLinkInfo(const char* exe, const char* args)
 
 	UTIL::FS::Path path = UTIL::FS::PathWithFile(exe);
 
-#ifdef WIN32
-	uint32 platform = 100;
-#else
-#ifdef NIX64
-	uint32 platform = 120;
-#else
-	uint32 platform = 110;
-#endif
-#endif
-
 	if (m_mBranchInstallInfo.size() == 0)
-		m_mBranchInstallInfo[platform] = new UserCore::Item::BranchInstallInfo(platform, this);
+		m_mBranchInstallInfo[BUILDID_PUBLIC] = new UserCore::Item::BranchInstallInfo(BUILDID_PUBLIC, this);
 
-	BranchInstallInfo *bii = m_mBranchInstallInfo[platform];
+	BranchInstallInfo *bii = m_mBranchInstallInfo[BUILDID_PUBLIC];
 
 	if (m_vBranchList.size() == 0)
 		m_vBranchList.push_back(new UserCore::Item::BranchInfo(MCFBranch::BranchFromInt(0), getId(), bii));

--- a/src/shared/usercore/code/ItemInfo.cpp
+++ b/src/shared/usercore/code/ItemInfo.cpp
@@ -347,6 +347,22 @@ void ItemInfo::loadDb(sqlite3x::sqlite3_connection* db)
 
 			m_vBranchList.push_back(bi);
 		}
+
+		// A TYPE_LINK may or may not have branches stored on disk, but will need one at runtime.
+		if(getId().getType() == DesuraId::TYPE_LINK && m_vBranchList.size() == 0) {
+#ifdef WIN32
+			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[100]);
+#else
+#ifdef NIX64
+			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[120]);
+#else
+			BranchInfo* bi = new BranchInfo(MCFBranch::BranchFromInt(m_INBranch), m_iId, m_mBranchInstallInfo[110]);
+#endif
+#endif
+			bi->setLinkInfo(getName());
+			m_vBranchList.push_back(bi);
+			m_INBranchIndex = 0;
+		}
 	}
 
 	setIconUrl(m_szIconUrl.c_str());

--- a/src/shared/usercore/code/ItemManager.cpp
+++ b/src/shared/usercore/code/ItemManager.cpp
@@ -99,16 +99,6 @@ ItemManager::~ItemManager()
 
 void ItemManager::migrateOldItemInfo(const char* olddb, const char* newdb)
 {
-#ifdef WIN32
-	uint32 biid = 100;
-#else
-#ifdef NIX64
-	uint32 biid = 120;
-#else
-	uint32 biid = 110;
-#endif
-#endif
-
 	sqlite3x::sqlite3_connection db(olddb);
 	sqlite3x::sqlite3_connection ndb(newdb);
 
@@ -225,7 +215,7 @@ void ItemManager::migrateOldItemInfo(const char* olddb, const char* newdb)
 				sqlite3x::sqlite3_command cmd(ndb, "INSERT OR IGNORE INTO installinfo VALUES (?,?,?,?,?, ?,?,?);");
 
 				cmd.bind(1, reader.getstring(0));
-				cmd.bind(2, (int)biid);
+				cmd.bind(2, BUILDID_PUBLIC);
 
 				cmd.bind(3, reader.getstring(14));
 				cmd.bind(4, reader.getstring(15));
@@ -259,7 +249,7 @@ void ItemManager::migrateOldItemInfo(const char* olddb, const char* newdb)
 			cmd.bind(9, reader.getstring(8));
 			cmd.bind(10, reader.getstring(9));
 			cmd.bind(11, reader.getstring(10));
-			cmd.bind(12, (int)biid);
+			cmd.bind(12, BUILDID_PUBLIC);
 
 			cmd.executenonquery();
 		}
@@ -274,7 +264,7 @@ void ItemManager::migrateOldItemInfo(const char* olddb, const char* newdb)
 			sqlite3x::sqlite3_command cmd(ndb, "INSERT OR IGNORE INTO exe VALUES (?,?,?,?,?, ?,?);");
 
 			cmd.bind(1, reader.getstring(0));
-			cmd.bind(2, (int)biid);
+			cmd.bind(2, BUILDID_PUBLIC);
 			cmd.bind(3, reader.getstring(1));
 			cmd.bind(4, reader.getstring(2));
 			cmd.bind(5, reader.getstring(3));


### PR DESCRIPTION
This fixes #223 for me, plus a related bug I found in testing it where a 64-bit only build refuses to run local links to 64-bit binaries with an error about 32-bit compatibility.

I've gone for the solution of regenerating each link's BranchInfo on start, since enough data **is** succesfully saved to do that and I can't see anything to suggest a "proper" branchid range they should be given instead.

Edit: I've also cleaned up some #ifdefs that are basically identical to my own.

works for:
- lodle (Windows)
- TheSiege (Linux 64)
