### PR TITLE
cmake: add Boost Include Dir to test targets

### DIFF
--- a/cmake/modules/macros.cmake
+++ b/cmake/modules/macros.cmake
@@ -99,7 +99,10 @@ macro(add_desura_test name category neededLibs)
                           ${CMAKE_SOURCE_DIR}/src/tests/${category}/${name}*.h
                           ${CMAKE_SOURCE_DIR}/src/tests/*.h)
     add_executable(${name} ${${name}_SRC})
-    include_directories(${CMAKE_SOURCE_DIR}/src/tests)
+    include_directories(
+      ${CMAKE_SOURCE_DIR}/src/tests
+      ${Boost_INCLUDE_DIRECTORY}
+    )
     target_link_libraries(${name}
       ${Boost_LIBRARIES}
       ${neededLibs}

--- a/cmake/modules/macros.cmake
+++ b/cmake/modules/macros.cmake
@@ -101,7 +101,7 @@ macro(add_desura_test name category neededLibs)
     add_executable(${name} ${${name}_SRC})
     include_directories(
       ${CMAKE_SOURCE_DIR}/src/tests
-      ${Boost_INCLUDE_DIRECTORY}
+      ${Boost_INCLUDE_DIR}
     )
     target_link_libraries(${name}
       ${Boost_LIBRARIES}


### PR DESCRIPTION
this will fix compile errors, if no /usr/include/boost directory is existing on system. This happens for example on gentoos boost-1.50-r2 ebuild
