### PR TITLE
usercore: escape \n in desktop files

### DIFF
--- a/src/shared/usercore/code/ItemHandle_nix.cpp
+++ b/src/shared/usercore/code/ItemHandle_nix.cpp
@@ -316,8 +316,10 @@ void ItemHandle::installLaunchScripts()
 
 inline gcString createDesktopFile(ItemInfoI* i)
 {
+	using boost::algorithm::replace_all_copy;
 	// KDE menu doesn't accept files like "Publisher Name-GameName.desktop" so we replace all " " with "_"
-	gcString publisher = boost::algorithm::replace_all_copy(std::string(i->getPublisher()), " ", "_");
+	gcString publisher = replace_all_copy(std::string(i->getPublisher()), " ", "_");
+	gcString comment = replace_all_copy(std::string(i->getDesc()), "\n", "\\n");
 
 	gcString tmpPath("{0}/{1}-{2}.desktop",
 	                 UTIL::OS::getCachePath(),
@@ -328,13 +330,17 @@ inline gcString createDesktopFile(ItemInfoI* i)
 	desktopFile << "[Desktop Entry]"
 	            << "\nType=Application"
 	            << "\nName=" << i->getName()
-	            << "\nComment=" << i->getDesc()
+	            << "\nComment=" << comment
 	            << "\nIcon=" << i->getIcon()
 	            << "\nTryExec=" << i->getActiveExe()->getExe()
 	            << "\nExec=" << i->getActiveExe()->getExe() << ' '
 	                         << i->getActiveExe()->getExeArgs()
-	            << "\nCategories=Game;" << i->getGenre() << ';'
-	            << std::endl;
+	            << "\nCategories=Game;";
+	// check for the genre first, before writing an empty string ("Categories=Game;;" is invalid)
+	if (std::string(i->getGenre()).size() > 0)
+		desktopFile << i->getGenre() << ';';
+	// finish the desktopFile
+	desktopFile << std::endl;
 	desktopFile.close();
 
 	return tmpPath;


### PR DESCRIPTION
we should escape a new line in the comment field of desktop files. Further we should check, if the genre is empty.

fixes #306
