### PR TITLE
Remeoved mkdir "package"

### DIFF
--- a/README
+++ b/README
@@ -74,10 +74,8 @@ Create Packages
 
 You can simply run the following commands to create packages for installing desura with your package manager:
 
- 1. mkdir package
- 2. cd package
- 3. cmake -DPACKAGE_TYPE="{PACKAGE_TYPE}" -DINSTALL_DESKTOP_FILE=ON -DCMAKE_INSTALL_PREFIX="/opt/desura" ..
- 4. make package
+ 1. cmake -DPACKAGE_TYPE="{PACKAGE_TYPE}" -DINSTALL_DESKTOP_FILE=ON -DCMAKE_INSTALL_PREFIX="/opt/desura"
+ 2. make package
 
 Supported Values for PACKAGE_TYPE are:
   * DEB


### PR DESCRIPTION
There is no need to create "package" folder. If user creates the "package" then cd's in the package folder and finaly runs the command to create the package, he/she will get an error from Cmake. 
Instead either just run the command on the root folder of the source code or add the code in the "package" folder e.g.:
1. mkdir package
2. cd package
3. extract here the source code
4. run cmake -DPACKAGE_TYPE="{PACKAGE_TYPE}" -DINSTALL_DESKTOP_FILE=ON -DCMAKE_INSTALL_PREFIX="/opt/desura"
5. make package
