### PR TITLE
util_thread: add a check against joinable in BaseThread::stop() before j...

### DIFF
--- a/src/static/util_thread/code/BaseThread.cpp
+++ b/src/static/util_thread/code/BaseThread.cpp
@@ -328,7 +328,10 @@ void BaseThread::stop()
 	if (m_pPrivates->m_pThread)
 	{
 		m_pPrivates->m_pThread->interrupt();
-		m_pPrivates->m_pThread->join();
+		if (m_pPrivates->m_pThread->joinable())
+		{
+			m_pPrivates->m_pThread->join();
+		}
 	}
 }
 


### PR DESCRIPTION
...oin

since boost 1.52 some threads are not joinable

this will fix #348

NOTE: this is a candidate for the stable branch
