### PR TITLE
Wx detect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ if(wxWidgets_FOUND)
     "-DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets_CONFIG_EXECUTABLE}"
     "-DwxWidgets_wxrc_EXECUTABLE=${wxWidgets_wxrc_EXECUTABLE}")
   if(NOT WXWIDGET_2_9_TEST_COMPILE)
+    message(STATUS "no working wxWidgets-2.9.3 found")
     unset(wxWidgets_FOUND)
     if(REQUIRED_IF_OPTION)
       message(FATAL_ERROR "no wxWidget-2.9.3 found")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,10 @@ if(wxWidgets_FOUND)
     "${CMAKE_TEST_PROJECTS_BIN}/wxWidget_2.9_test"
     "${CMAKE_TEST_PROJECTS}/wxWidget_2.9_test"
     "wxWidget_2_9_test"
-    "wxWidget_2_9_test")
+    "wxWidget_2_9_test"
+    CMAKE_FLAGS
+    "-DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets_CONFIG_EXECUTABLE}"
+    "-DwxWidgets_wxrc_EXECUTABLE=${wxWidgets_wxrc_EXECUTABLE}")
   if(NOT WXWIDGET_2_9_TEST_COMPILE)
     unset(wxWidgets_FOUND)
     if(REQUIRED_IF_OPTION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@
 #   INSTALL_DESKTOP_FILE                INSTALL a desktop file in /usr/share/applications
 #                   OFF
 #
+# wxWidgets select correct  version
+#   wxWidgets_CONFIG_EXECUTABLE         path to wx-config (version 2.9.3)
+#   wxWidgets_wxrc_EXECUTABLE           path to wxrc (version 2.9.3)
+#
 # windows-only options:
 #   BOOST_URL                           URL to boost archive
 #


### PR DESCRIPTION
If someone want to use system wxWidgets with Desurium he would probably have default 2.8 version and 2.9.3 as a choice. But if 2.9.3 is not default, than even if wxWidgets_CONFIG_EXECUTABLE and wxWidgets_wxrc_EXECUTABLE is set, the test will fail because those options are not passed to the test. This pull is fixing the issue.
