### PR TITLE
wx_controls: fix workaround

### DIFF
--- a/src/shared/uicore/code/UploadProgPage.cpp
+++ b/src/shared/uicore/code/UploadProgPage.cpp
@@ -57,7 +57,8 @@ UploadProgPage::UploadProgPage( wxWindow* parent, wxWindowID id, const wxPoint& 
 	bSizer5->Add( m_labTimeLeft, 0, wxALIGN_BOTTOM|wxTOP|wxRIGHT, 5 );
 	
 
-	m_pbProgress = static_cast<gcULProgressBar*>(new gcProgressBar(this, wxID_ANY, wxDefaultPosition, wxSize( -1,22 )));
+	m_pbProgress = new gcULProgressBar( this, wxID_ANY );
+
 
 	m_cbDeleteMcf = new gcCheckBox( this, wxID_ANY, Managers::GetString(L"#UDF_DELETE"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_cbDeleteMcf->SetValue( true ); 

--- a/src/static/wx_controls/code/gcUpProgBar.cpp
+++ b/src/static/wx_controls/code/gcUpProgBar.cpp
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 
 
-gcULProgressBar::gcULProgressBar(wxWindow *parent, int id) : gcProgressBar(parent, id)
+gcULProgressBar::gcULProgressBar(wxWindow *parent, int id) : gcProgressBar(parent, id, wxDefaultPosition, wxSize( -1,22 ))
 {
 	m_uiLastMS = 0;
 }


### PR DESCRIPTION
this reuqest fixes a workaround in 1f343f1ea858a652716599474d64dc691c0ab60d introduced #362.
Instead of creating a new instance of an incompatible class I fixed the height in gcULProgressBar directly.

This bug was caused, because gcULProgressBar had a uint8_t field, which resulted into some errors within glibc.

This pull request will fix both #362 and #408

NOTE: this is a candidate for the stable branch
