### PR TITLE
test: remove getAppPath test in UtilLinux_test

### DIFF
--- a/src/tests/util/UtilLinux_test.cpp
+++ b/src/tests/util/UtilLinux_test.cpp
@@ -14,21 +14,6 @@ using namespace boost;
 using namespace boost::unit_test;
 using namespace UTIL::LIN;
 
-// should be removed later
-namespace std
-{
-	std::ostream &operator<<(std::ostream &os, const std::wstring &ws) 
-	{ 
-		return os << UTIL::STRING::toStr(ws); 
-	} 
-}
-
-BOOST_AUTO_TEST_CASE (UTIL_LIN_getAppPath)
-{
-	BOOST_REQUIRE_EQUAL(getAppPath(L""), filesystem::current_path().wstring());
-	BOOST_REQUIRE_EQUAL(getAppPath(L"test/path"), (filesystem::current_path() / "test/path").wstring());
-}
-
 BOOST_AUTO_TEST_CASE (Util_Lin_String_Output)
 {
 	std::cout << "-- Testing UTIL::LIN::getDesktopPath(...) --\n";


### PR DESCRIPTION
this function will be tested by "GUI" Test cases as well.

If it's working desurium will start correctly, if not then not.
It doesn't make sense to test this function the same way it was implemented.

fixes #392

NOTE: this is a candidate for the stable branch
