### PR TITLE
cmake: mac os X requires cmake 2.8.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,12 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX
 
 # TODO: silent output for externel dependencies
 project(Desura)
-cmake_minimum_required(VERSION 2.8.5)
+
+if(APPLE) # see #418
+  cmake_minimum_required(VERSION 2.8.10)
+else()
+  cmake_minimum_required(VERSION 2.8.5)
+endif()
 
 ###############################################################################
 # some globale variables


### PR DESCRIPTION
prior versions are shipped without SSL support (used by ExternalProject)

fixes #418
