### PR TITLE
Cppcheck fixes

### DIFF
--- a/src/common/gcJSBase.cpp
+++ b/src/common/gcJSBase.cpp
@@ -283,7 +283,7 @@ void DesuraJSBaseNonTemplate::registerFunction(const char* name, JSDelegateI *de
 
 uint32 DesuraJSBaseNonTemplate::find(uint32 hash)
 {
-	if (m_mDelegateList.size() == 0)
+	if (m_mDelegateList.empty())
 		return -1;
 
 	return find(hash, 0, m_mDelegateList.size()-1);

--- a/src/common/gcJSBase.cpp
+++ b/src/common/gcJSBase.cpp
@@ -201,13 +201,10 @@ JSObjHandle ToJSObject(ChromiumDLL::JavaScriptFactoryI* factory, const void* cob
 ////////////////////////////////////////////
 
 DesuraJSBaseNonTemplate::DesuraJSBaseNonTemplate(const char* name, const char* bindingFile)
-{
-	m_szName = gcString(L"Desura/{0}", name);
-	m_szBindingFile = gcString("{2}{1}bindings{1}{0}", bindingFile, DIRS_STR,
-		UTIL::OS::getDataPath());
-
-	m_pContext = NULL;
-}
+:	m_szName(L"Desura/{0}", name),
+	m_szBindingFile("{2}{1}bindings{1}{0}", bindingFile, DIRS_STR, UTIL::OS::getDataPath()),
+	m_pContext(NULL)
+{}
 
 DesuraJSBaseNonTemplate::~DesuraJSBaseNonTemplate()
 {

--- a/src/common/service_pipe/IPCServiceMain.cpp
+++ b/src/common/service_pipe/IPCServiceMain.cpp
@@ -503,10 +503,9 @@ class AddToWGETask : public TaskI
 {
 public:
 	AddToWGETask(const char* name, const char* dllPath)
-	{
-		m_szDllPath = dllPath;
-		m_szName = name;
-	}
+	:	m_szDllPath(dllPath),
+		m_szName(name)
+	{}
 
 	void doTask()
 	{
@@ -527,10 +526,9 @@ class RemoveFromWGETask : public TaskI
 {
 public:
 	RemoveFromWGETask(const char* dllPath, bool deleteDll)
-	{
-		m_szDllPath = dllPath;
-		m_bDelete = deleteDll;
-	}
+	:	m_szDllPath(dllPath),
+		m_bDelete(deleteDll)
+	{}
 
 	void doTask()
 	{

--- a/src/executable/desura_browserhost/code/CefSchemeBase.h
+++ b/src/executable/desura_browserhost/code/CefSchemeBase.h
@@ -47,13 +47,11 @@ class DesuraSchemeBase : public ChromiumDLL::SchemeExtenderI
 {
 public:
 	DesuraSchemeBase(const char* schemename, const char* hostname)
-	{
-		m_szHostname = hostname;
-		m_szSchemename = schemename;
-
-		m_pCallback = NULL;
-		m_uiResponseSize = 0;
-	}
+	:	m_uiResponseSize(0),
+		m_pCallback(NULL),
+		m_szHostname(hostname),
+		m_szSchemename(schemename)
+	{}
 
 	virtual SchemeExtenderI* clone(const char* scheme)
 	{

--- a/src/include/BaseManager.h
+++ b/src/include/BaseManager.h
@@ -36,8 +36,8 @@ public:
 	}
 
 	BaseItem(const char* name)
+	:	m_szName(name)
 	{
-		m_szName =  gcString(name);
 		m_uiHash = UTIL::MISC::RSHash_CSTR(name);
 	}
 

--- a/src/include/BaseManager.h
+++ b/src/include/BaseManager.h
@@ -86,7 +86,7 @@ public:
 
 	T* findItem(uint64 hash)
 	{
-		if (m_mItemMap.size() == 0)
+		if (m_mItemMap.empty())
 			return NULL;
 
 		typename std::map<uint64,T*>::iterator it = m_mItemMap.find(hash);
@@ -150,7 +150,7 @@ protected:
 
 	void removeItem(uint64 hash, bool del = false)
 	{
-		if (m_mItemMap.size() == 0)
+		if (m_mItemMap.empty())
 			return;
 
 		typename std::map<uint64, T*>::iterator it = m_mItemMap.find(hash);

--- a/src/include/DesuraId.h
+++ b/src/include/DesuraId.h
@@ -130,7 +130,7 @@ public:
 
 	gcString getTypeString() const
 	{
-		return DesuraId::getTypeString(m_uiType);
+		return getTypeString(m_uiType);
 	}
 
 	uint64 toInt64() const

--- a/src/include/managers/WildcardManager.h
+++ b/src/include/managers/WildcardManager.h
@@ -53,14 +53,12 @@ public:
 class WildcardInfo : public BaseItem
 {
 public:
-	WildcardInfo(const char* name, const char* path, const char* type, bool resolved = false) : BaseItem(name)
-	{
-		m_szName = name;
-		m_szPath = path;
-		m_szType = type;
-
-		m_bResolved = resolved;
-	}
+	WildcardInfo(const char* name, const char* path, const char* type, bool resolved = false) : BaseItem(name),
+		m_szName(name),
+		m_szPath(path),
+		m_szType(type),
+		m_bResolved(resolved)
+	{}
 
 	~WildcardInfo()
 	{

--- a/src/include/mcfcore/DownloadProvider.h
+++ b/src/include/mcfcore/DownloadProvider.h
@@ -65,12 +65,11 @@ public:
 	//! @param p Provider Url
 	//!
 	DownloadProvider(const char* n, const char* u, const char* b, const char* p)
-	{
-		m_szName = gcString(n);
-		m_szUrl = gcString(u);
-		m_szBanner = gcString(b);
-		m_szProvUrl = gcString(p);
-	}
+	:	m_szName(n),
+		m_szUrl(u),
+		m_szBanner(b),
+		m_szProvUrl(p)
+	{}
 
 	//! Alt Constructor from xml
 	//! 

--- a/src/include/usercore/GuiDownloadProvider.h
+++ b/src/include/usercore/GuiDownloadProvider.h
@@ -41,16 +41,14 @@ public:
 	}
 
 	GuiDownloadProvider(uint32 a, MCFCore::Misc::DownloadProvider* dp)
-	{
-		action = a;
-		provider = dp;
-	}
+	:	action(a),
+		provider(dp)
+	{}
 
 	GuiDownloadProvider(GuiDownloadProvider& dp)
-	{
-		action = dp.action;
-		provider = dp.provider;
-	}
+	:	action(dp.action),
+		provider(dp.provider)
+	{}
 
 	uint32 action;
 	MCFCore::Misc::DownloadProvider provider;

--- a/src/include/usercore/ItemInfoI.h
+++ b/src/include/usercore/ItemInfoI.h
@@ -543,11 +543,10 @@ public:
 	//! @param ii Item object
 	//!
 	ItemUpdateInfo(DesuraId i, MCFBuild b, ItemInfoI *ii)
-	{
-		id = i;
-		build = b;
-		info = ii;
-	}
+	:	id(i),
+		build(b),
+		info(ii)
+	{}
 
 	DesuraId id;
 	MCFBuild build;

--- a/src/include/util/gcString.h
+++ b/src/include/util/gcString.h
@@ -897,7 +897,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 	CT dot = converToStringType<CT>(".")[0];
 	CT comma = converToStringType<CT>(",")[0];
 
-	while (t.size() > 0)
+	while (!t.empty())
 	{
 		if (t.size() == 1)
 		{
@@ -927,7 +927,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 
 				t.erase(0, 1);
 
-				if (t.size() == 0)
+				if (t.empty())
 				{
 					ret += leftBracket;
 					ret += temp;
@@ -935,14 +935,14 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 				}
 			}
 
-			if (t.size() == 0)
+			if (t.empty())
 				break;
 
 			orig = temp;
 
 			t.erase(0, 1);
 
-			if (temp.size() == 0)
+			if (temp.empty())
 			{
 				ret += leftBracket;
 				ret += rightBracket;
@@ -986,7 +986,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 				temp.erase(0, 1);
 				std::basic_string<CT> temp2;
 
-				while (temp.size() > 0 && temp[0] != dot && temp[0] != colon)
+				while (!temp.empty() && temp[0] != dot && temp[0] != colon)
 				{
 					if (isdigit(temp[0]) == false)
 					{
@@ -1002,7 +1002,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 					temp.erase(0, 1);
 				} 
 
-				if (temp2.size() > 0)
+				if (!temp2.empty())
 					len = atoi(temp2.c_str());
 			}
 
@@ -1011,7 +1011,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 				temp.erase(0, 1);
 				std::basic_string<CT> temp2;
 
-				while (temp.size() > 0 && temp[0] != colon)
+				while (!temp.empty() && temp[0] != colon)
 				{
 					if (isdigit(temp[0]) == false)
 					{
@@ -1027,7 +1027,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 					temp.erase(0, 1);
 				} 
 
-				if (temp2.size() > 0)
+				if (!temp2.empty())
 					per = atoi(temp2.c_str());
 			}
 
@@ -1036,7 +1036,7 @@ std::basic_string<CT> FormatString(const CT* format, std::vector<FormatArgI<CT>*
 				temp.erase(0, 1);
 				std::basic_string<CT> temp2;
 
-				while (temp.size() > 0 && temp[0] != colon)
+				while (!temp.empty() && temp[0] != colon)
 				{
 					if (isalnum(temp[0]) == false)
 					{

--- a/src/include/webcore/DLLVersion.h
+++ b/src/include/webcore/DLLVersion.h
@@ -46,13 +46,12 @@ public:
 	//! @param u UserCore Version
 	//!
 	DLLVersion(const char* d, const char* ui, const char* w, const char* m, const char* u)
-	{
-		szMcfVer = gcString(m);
-		szDEVer = gcString(d);
-		szUIVer = gcString(ui);
-		szWebVer = gcString(w);
-		szUserVer = gcString(u);
-	}
+	:	szMcfVer(m),
+		szDEVer(d),
+		szUIVer(ui),
+		szWebVer(w),
+		szUserVer(u)
+	{}
 
 	//! Copy Constuctor
 	//!

--- a/src/include/webcore/DownloadImageInfo.h
+++ b/src/include/webcore/DownloadImageInfo.h
@@ -30,15 +30,13 @@ namespace Misc
 	{
 	public:
 		DownloadImageInfo(DesuraId i, gcString u)
-		{
-			id = i;
-			url = u;
-		}
+		:	id(i),
+			url(u)
+		{}
 
 		DownloadImageInfo(gcString u)
-		{
-			url = u;
-		}
+		:	url(u)
+		{}
 
 		DesuraId id;
 		gcString url;

--- a/src/shared/mcfcore/code/MCFDPReporter.cpp
+++ b/src/shared/mcfcore/code/MCFDPReporter.cpp
@@ -122,34 +122,11 @@ void DPReproter::resetStart()
 	m_uiTotal = 0;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-DPProvider::DPProvider(const char* name, uint32 id) : BaseItem()
+DPProvider::DPProvider(const char* name, uint32 id) : BaseItem(),
+	m_szName(name),
+	m_uiId(id)
 {
-	m_uiId = id;
 	m_uiHash = id;
-	m_szName = gcString(name);
-	
 	m_tStart = bpt::ptime(bpt::microsec_clock::universal_time());
 
 	clear();

--- a/src/shared/mcfcore/code/mcf/MCFFile.cpp
+++ b/src/shared/mcfcore/code/mcf/MCFFile.cpp
@@ -453,7 +453,7 @@ void MCFFile::genXml(XMLSaveAndCompress *sac)
 		sac->save("</diff>", 7);
 	}
 
-	if (m_vCRCList.size() > 0)
+	if (!m_vCRCList.empty())
 	{
 		size_t size = m_vCRCList.size()*4;
 		UTIL::MISC::Buffer data(size, true);
@@ -714,7 +714,7 @@ bool MCFFile::crcCheck(UTIL::FS::FileHandle& file)
 
 bool MCFFile::crcCheck(uint16 blockId, UTIL::FS::FileHandle& file)
 {
-	if (m_vCRCList.size() != 0 && blockId >= m_vCRCList.size())
+	if (!m_vCRCList.empty() && blockId >= m_vCRCList.size())
 	{
 		//corupt MCF header. Cant do much about it
 		return false;
@@ -742,7 +742,7 @@ bool MCFFile::crcCheck(uint16 blockId, UTIL::FS::FileHandle& file)
 
 	bool res = false;
 
-	if ( m_vCRCList.size() == 0 )
+	if ( m_vCRCList.empty() )
 	{
 		res = legacyBlockCheck(buff, todo);
 	}

--- a/src/shared/mcfcore/code/thread/HGTController.cpp
+++ b/src/shared/mcfcore/code/thread/HGTController.cpp
@@ -353,7 +353,7 @@ void HGTController::fillDownloadList(bool &usingDiffs)
 
 	std::sort(vBlockList.begin(), vBlockList.end(), &WGTBlockSort);
 
-	while (vBlockList.size() > 0)
+	while (!vBlockList.empty())
 	{
 		Misc::WGTSuperBlock* sb = new Misc::WGTSuperBlock();
 		sb->offset = vBlockList[0]->webOffset;
@@ -366,7 +366,7 @@ void HGTController::fillDownloadList(bool &usingDiffs)
 			sb->size += block->size;
 			sb->vBlockList.push_back(block);
 		}
-		while (vBlockList.size() > 0 && vBlockList[0]->webOffset == (sb->offset + sb->size));
+		while (!vBlockList.empty() && vBlockList[0]->webOffset == (sb->offset + sb->size));
 
 		m_vSuperBlockList.push_back(sb);
 	}
@@ -399,7 +399,7 @@ bool HGTController::saveData(const char* data, uint32 size)
 	if (size == 0)
 		return false;
 
-	if (!m_pCurBlock || m_pCurBlock->vBlockList.size() == 0)
+	if (!m_pCurBlock || m_pCurBlock->vBlockList.empty())
 		return true;
 
 	MCFCore::Thread::Misc::WGTBlock* block = m_pCurBlock->vBlockList[0];

--- a/src/shared/mcfcore/code/thread/SFTController.cpp
+++ b/src/shared/mcfcore/code/thread/SFTController.cpp
@@ -300,7 +300,7 @@ SFTWorkerBuffer* SFTController::getBlock(uint32 id, uint32 &status)
 	worker->mutex.lock();
 		status = worker->status;
 
-		if (worker->vBuffer.size() > 0)
+		if (!worker->vBuffer.empty())
 		{
 			temp = worker->vBuffer.front();
 			worker->vBuffer.erase(worker->vBuffer.begin());

--- a/src/shared/scriptcore/code/ScriptTaskThread.cpp
+++ b/src/shared/scriptcore/code/ScriptTaskThread.cpp
@@ -68,7 +68,7 @@ void ScriptTaskThread::run()
 
 		m_LockMutex.lock();
 
-		if (m_TaskQue.size() > 0)
+		if (!m_TaskQue.empty())
 		{
 			curTask = m_TaskQue.front();
 			m_TaskQue.pop_front();

--- a/src/shared/servicecore/code/ServiceMainThread.cpp
+++ b/src/shared/servicecore/code/ServiceMainThread.cpp
@@ -64,7 +64,7 @@ void ServiceMainThread::run()
 
 		m_vLock.lock();
 
-		if (m_vJobList.size() > 0)
+		if (!m_vJobList.empty())
 		{
 			task = m_vJobList.front();
 			m_vJobList.pop_front();

--- a/src/shared/uicore/code/BaseToolBarControl.cpp
+++ b/src/shared/uicore/code/BaseToolBarControl.cpp
@@ -20,9 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "BaseToolBarControl.h"
 
 
-BaseToolBarControl::BaseToolBarControl(wxWindow* parent) : gcPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(-1,29), wxTAB_TRAVERSAL)
+BaseToolBarControl::BaseToolBarControl(wxWindow* parent) : gcPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(-1,29), wxTAB_TRAVERSAL),
+	m_imgBg(GetGCThemeManager()->getImageHandle("#header_bg"))
 {
-	m_imgBg = GetGCThemeManager()->getImageHandle("#header_bg");
 	SetBackgroundColour( wxColour( 0, 113, 141 ) );
 
 	Bind(wxEVT_ERASE_BACKGROUND, &BaseToolBarControl::onEraseBG, this);

--- a/src/shared/uicore/code/InstallWaitPage.cpp
+++ b/src/shared/uicore/code/InstallWaitPage.cpp
@@ -23,14 +23,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 class ItemPanel : public gcPanel
 {
 public:
-	ItemPanel(wxWindow* parent, UserCore::Item::ItemInfoI* item, bool last) : gcPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL)
+	ItemPanel(wxWindow* parent, UserCore::Item::ItemInfoI* item, bool last) : gcPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL),
+		m_Id(item->getId()),
+		m_imgIcon(new gcImageControl(this, wxID_ANY, wxDefaultPosition, wxSize( 22,22 ), 0)),
+		m_labTitle(new wxStaticText(this, wxID_ANY, item->getName(), wxDefaultPosition, wxDefaultSize, 0)),
+		m_pbProgress(new gcProgressBar(this, wxID_ANY, wxDefaultPosition, wxSize( 150,18 )))
 	{
-		m_Id = item->getId();
-
-		m_imgIcon = new gcImageControl(this, wxID_ANY, wxDefaultPosition, wxSize( 22,22 ), 0);
-		m_labTitle = new wxStaticText(this, wxID_ANY, item->getName(), wxDefaultPosition, wxDefaultSize, 0);
-		m_pbProgress = new gcProgressBar(this, wxID_ANY, wxDefaultPosition, wxSize( 150,18 ));
-
 		const char* ico = item->getIcon();
 
 		if (ico && UTIL::FS::isValidFile(ico))

--- a/src/shared/uicore/code/MenuStrip.cpp
+++ b/src/shared/uicore/code/MenuStrip.cpp
@@ -104,7 +104,7 @@ int32 MenuStrip::addButton(const char* name)
 	temp->SetWindowStyle(wxALIGN_CENTER);
 	temp->setBold(true);
 
-	if (m_vButtons.size() == 0)
+	if (m_vButtons.empty())
 		m_vButtons.push_back(newSerperator());
 
 	m_vButtons.push_back(temp);

--- a/src/shared/uicore/code/SteamUser.cpp
+++ b/src/shared/uicore/code/SteamUser.cpp
@@ -45,7 +45,7 @@ int GetSteamUsers(wxChoice *cbBox)
 	std::vector<UTIL::FS::Path> fileList;
 	UTIL::FS::getAllFolders(UTIL::FS::Path(searchPath, "", false), fileList);
 
-	if (fileList.size() == 0)
+	if (fileList.empty())
 	{
 		cbBox->Append(wxT(NOSTEAM));
 		return 0;

--- a/src/shared/usercore/code/BranchInfo.cpp
+++ b/src/shared/usercore/code/BranchInfo.cpp
@@ -30,12 +30,11 @@ namespace Item
 {
 
 BranchInfo::BranchInfo(MCFBranch branchId, DesuraId itemId, BranchInstallInfo* bii, uint32 platformId)
+:	m_InstallInfo(bii),
+	m_ItemId(itemId),
+	m_uiBranchId(branchId),
+	m_uiFlags(0)
 {
-	m_InstallInfo = bii;
-	m_ItemId = itemId;
-	m_uiBranchId = branchId;
-	m_uiFlags = 0;
-
 	if (platformId != 0)
 	{
 		switch (platformId)

--- a/src/shared/usercore/code/BranchInstallInfo.h
+++ b/src/shared/usercore/code/BranchInstallInfo.h
@@ -43,10 +43,9 @@ class ExeInfo : public Misc::ExeInfoI
 {
 public:
 	ExeInfo(const char* name)
-	{
-		m_szName = name;
-		m_uiRank = -1;
-	}
+	:	m_szName(name),
+		m_uiRank(-1)
+	{}
 
 	virtual const char* getName()
 	{

--- a/src/shared/usercore/code/InstallInfo.cpp
+++ b/src/shared/usercore/code/InstallInfo.cpp
@@ -27,11 +27,10 @@ namespace Misc
 {
 
 InstallInfo::InstallInfo(DesuraId id, DesuraId pid)
-{
-	m_bInstalled = false;
-	m_iID = id;
-	m_iParentID = pid;
-}
+:	m_bInstalled(false),
+	m_iID(id),
+	m_iParentID(pid)
+{}
 
 InstallInfo::~InstallInfo()
 {

--- a/src/shared/usercore/code/ToolInfo.cpp
+++ b/src/shared/usercore/code/ToolInfo.cpp
@@ -85,9 +85,8 @@ class Operator : public OutValI
 {
 public:
 	Operator(std::string val)
-	{
-		m_szVal = val;
-	}
+	:	m_szVal(val)
+	{}
 
 	virtual bool isOperand()
 	{
@@ -131,12 +130,11 @@ namespace UserCore
 {
 
 ToolInfo::ToolInfo(DesuraId id)
+:	m_ToolId(id),
+	m_uiDownloadSize(0),
+	m_uiFlags(0)
 {
-	m_ToolId = id;
 	m_uiHash = id.toInt64();
-
-	m_uiDownloadSize = 0;
-	m_uiFlags = 0;
 }
 
 ToolInfo::~ToolInfo()

--- a/src/shared/usercore/code/ToolInfo.cpp
+++ b/src/shared/usercore/code/ToolInfo.cpp
@@ -426,13 +426,13 @@ bool ToolInfo::processResultString()
 		}
 		else if (c == ')')
 		{
-			while (opStack.size() > 0 && opStack.back() != "(")
+			while (!opStack.empty() && opStack.back() != "(")
 			{
 				if (!processStack(m_vRPN, valStack, opStack))
 					return false;
 			}
 
-			if (opStack.size() == 0)
+			if (opStack.empty())
 				return false;
 
 			opStack.pop_back();
@@ -471,7 +471,7 @@ bool ToolInfo::processResultString()
 			c = *it;
 
 
-			while (opStack.size() > 0 && opStack.back() != "(" && (getOperatorOrder(val) > getOperatorOrder(opStack.back())))
+			while (!opStack.empty() && opStack.back() != "(" && (getOperatorOrder(val) > getOperatorOrder(opStack.back())))
 			{
 				if (!processStack(m_vRPN, valStack, opStack))
 					return false;
@@ -487,7 +487,7 @@ bool ToolInfo::processResultString()
 	}
 
 
-	while (opStack.size() > 0)
+	while (!opStack.empty())
 	{
 		if (opStack.back() == "(")
 			return false;
@@ -496,7 +496,7 @@ bool ToolInfo::processResultString()
 			return false;
 	}
 
-	while (valStack.size() > 0)
+	while (!valStack.empty())
 	{
 		m_vRPN.push_back(new Operand(valStack.back()));
 		valStack.pop_back();
@@ -507,10 +507,10 @@ bool ToolInfo::processResultString()
 
 bool ToolInfo::checkExpectedResult(uint32 res)
 {
-	if (m_szResult.size() == 0)
+	if (m_szResult.empty())
 		return true;
 
-	if (m_vRPN.size() == 0)
+	if (m_vRPN.empty())
 	{
 		if (!processResultString())
 		{
@@ -526,7 +526,7 @@ bool ToolInfo::checkExpectedResult(uint32 res)
 	std::deque<OutValI*> vList = m_vRPN;
 	std::vector<int32> stack;
 
-	while (vList.size() > 0)
+	while (!vList.empty())
 	{
 		OutValI* item = vList.front();
 		vList.pop_front();
@@ -602,10 +602,10 @@ bool ToolInfo::checkExpectedResult(uint32 res)
 		}
 	}
 
-	if (stack.size() > 1)
+	if (!stack.empty())
 		Warning(gcString("To many items left on stack after results calc for tool {0}.", getName()));
 
-	if (stack.size() == 0)
+	if (stack.empty())
 		return true;
 
 	return stack.front()?true:false;

--- a/src/shared/utilcore/code/MiniDumpGenerator_Extern.cpp
+++ b/src/shared/utilcore/code/MiniDumpGenerator_Extern.cpp
@@ -33,10 +33,9 @@ BOOL CALLBACK MiniDumpCallbackFilter(PVOID pParam, const PMINIDUMP_CALLBACK_INPU
 
 
 MiniDumpGenerator_Extern::MiniDumpGenerator_Extern(const char* exeName, const char* savePath)
+:	m_szExeName(exeName),
+	m_szSavePath(savePath)
 {
-	m_szExeName = exeName;
-	m_szSavePath = savePath;
-
 	UTIL::FS::recMakeFolder(UTIL::FS::PathWithFile(m_szSavePath));
 }
 

--- a/src/static/ipc_pipe/code/IPCClass.cpp
+++ b/src/static/ipc_pipe/code/IPCClass.cpp
@@ -103,9 +103,9 @@ uint32 deserializeList(std::vector<IPCParameterI*> &list, const char* buffer, ui
 
 
 IPCClass::IPCClass(IPCManager* mang, uint32 id, DesuraId itemId)
+:	m_uiItemId(itemId),
+	m_pManager(mang)
 {
-	m_uiItemId = itemId;
-	m_pManager = mang;
 	m_uiId = id;
 }
 

--- a/src/static/ipc_pipe/code/IPCManager.cpp
+++ b/src/static/ipc_pipe/code/IPCManager.cpp
@@ -176,7 +176,7 @@ protected:
 
 			m_mVectorMutex.lock();
 
-				if (m_vItemList.size() > 0)
+				if (!m_vItemList.empty())
 				{
 					e = SmartPtr<ProcessData>(m_vItemList[0]);
 					m_vItemList.erase(m_vItemList.begin());
@@ -586,7 +586,7 @@ bool IPCManager::getMessageToSend(char* buffer, uint32 buffSize, uint32& msgSize
 	PipeMessage *msg = NULL;
 
 	m_mVectorMutex.lock();
-	if (m_vPipeMsgs.size() > 0)
+	if (!m_vPipeMsgs.empty())
 	{
 		msg = m_vPipeMsgs.front();
 		m_vPipeMsgs.erase(m_vPipeMsgs.begin());

--- a/src/static/ipc_pipe/code/IPCPipeAuth.h
+++ b/src/static/ipc_pipe/code/IPCPipeAuth.h
@@ -29,9 +29,8 @@ class PipeItemAuth
 {
 public:
 	PipeItemAuth()
-	{
-		internId = 0;
-	}
+	:	internId(0)
+	{}
 
 	gcString hash;
 	DesuraId internId;

--- a/src/static/ipc_pipe/code/IPCPipeBase.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeBase.cpp
@@ -52,11 +52,10 @@ namespace IPC
 FILE* fh = NULL;
 #endif
 
-PipeBase::PipeBase(const char* pipeName, const char* threadName) : BaseThread(threadName)
+PipeBase::PipeBase(const char* pipeName, const char* threadName) : BaseThread(threadName),
+	m_szRecvName("\\\\.\\pipe\\{0}-r", pipeName),
+	m_szSendName("\\\\.\\pipe\\{0}-s", pipeName)
 {
-	m_szRecvName = gcString("\\\\.\\pipe\\{0}-r", pipeName);
-	m_szSendName = gcString("\\\\.\\pipe\\{0}-s", pipeName);
-
 	for (size_t x=0; x<512; x++)
 	{
 		m_hEventsArr[x] = INVALID_HANDLE_VALUE;

--- a/src/static/ipc_pipe/code/IPCPipeBase.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeBase.cpp
@@ -118,7 +118,7 @@ void PipeBase::processLoopback()
 {
 	m_LoopbackLock.lock();
 
-	if (m_vLoopback.size() > 0)
+	if (!m_vLoopback.empty())
 	{
 		LoopbackInfo* info = m_vLoopback.front();
 		m_vLoopback.pop_front();

--- a/src/static/ipc_pipe/code/IPCPipeBase_Nix.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeBase_Nix.cpp
@@ -101,7 +101,7 @@ void PipeBase::processLoopback()
 {
 	m_LoopbackLock.lock();
 
-	if (m_vLoopback.size() > 0)
+	if (!m_vLoopback.empty())
 	{
 		LoopbackInfo* info = m_vLoopback.front();
 		m_vLoopback.pop_front();

--- a/src/static/managers/code/CVarManager.cpp
+++ b/src/static/managers/code/CVarManager.cpp
@@ -59,11 +59,13 @@ void SaveCVars()
 #define COUNT_CVAR "SELECT count(*) FROM sqlite_master WHERE name='cvar';"
 
 
-CVarManager::CVarManager() : BaseManager<CVar>()
+CVarManager::CVarManager() : BaseManager<CVar>(),
+	m_uiUserId(-1),
+	m_szCVarDb(UTIL::OS::getAppDataPath(L"settings_b.sqlite")),
+	m_bUserLoaded(false),
+	m_bWinUserLoaded(false),
+	m_bNormalLoaded(false)
 {
-	m_uiUserId = -1;
-
-	m_szCVarDb = UTIL::OS::getAppDataPath(L"settings_b.sqlite");
 	UTIL::FS::recMakeFolder(UTIL::FS::Path(m_szCVarDb, "", true));
 
 	try
@@ -83,10 +85,6 @@ CVarManager::CVarManager() : BaseManager<CVar>()
 	{
 		Warning(gcString("Failed to create cvar tables: {0}\n", e.what()));
 	}
-
-	m_bUserLoaded = false;
-	m_bWinUserLoaded = false;
-	m_bNormalLoaded = false;
 }
 
 CVarManager::~CVarManager()

--- a/src/static/managers/code/Theme.cpp
+++ b/src/static/managers/code/Theme.cpp
@@ -20,10 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "Theme.h"
 #include "XMLMacros.h"
 
-Theme::Theme(const char* name) : ControlList(true), ImageList(true), SpriteList(true), WebList(true)
-{
-	m_szName = gcString(name);
-}
+Theme::Theme(const char* name) : ControlList(true), ImageList(true), SpriteList(true), WebList(true),
+	m_szName(name)
+{}
 
 const char* Theme::getImage(const char* id)
 {

--- a/src/static/managers/code/ThemeManager.cpp
+++ b/src/static/managers/code/ThemeManager.cpp
@@ -29,9 +29,8 @@ class ThemeStub : public ThemeStubI
 {
 public:
 	ThemeStub(const char* name)
-	{
-		szName = name;
-	}
+	:	szName(name)
+	{}
 
 	virtual const char* getName(){return szName.c_str();}
 
@@ -49,14 +48,6 @@ public:
 	virtual bool parseFile(const char* file);
 	virtual void destroy(){delete this;}
 };
-
-
-
-
-
-
-
-
 
 ThemeManager::ThemeManager()
 {

--- a/src/static/scriptengine/code/ScriptCore.cpp
+++ b/src/static/scriptengine/code/ScriptCore.cpp
@@ -142,11 +142,11 @@ public:
 class RunScript : public ScriptTask
 {
 public:
-	RunScript(ScriptCoreInternal* scriptInternal, const char* file, char* buff, uint32 size) : ScriptTask(scriptInternal), m_AutoDelBuff(buff)
-	{
-		m_szFile = file;
-		m_uiSize = size;
-	}
+	RunScript(ScriptCoreInternal* scriptInternal, const char* file, char* buff, uint32 size) : ScriptTask(scriptInternal),
+		m_AutoDelBuff(buff),
+		m_szFile(file),
+		m_uiSize(size)
+	{}
 
 	virtual void run()
 	{
@@ -162,10 +162,9 @@ public:
 class RunString : public ScriptTask
 {
 public:
-	RunString(ScriptCoreInternal* scriptInternal, const char* string) : ScriptTask(scriptInternal)
-	{
-		m_szString = string;
-	}
+	RunString(ScriptCoreInternal* scriptInternal, const char* string) : ScriptTask(scriptInternal),
+		m_szString(string)
+	{}
 
 	virtual void run()
 	{

--- a/src/static/scriptengine/code/jsItem.cpp
+++ b/src/static/scriptengine/code/jsItem.cpp
@@ -120,7 +120,7 @@ JSObjHandle ItemJSBinding::execute(ChromiumDLL::JavaScriptFunctionArgs* args)
 {
 	JSObjHandle ret =  DesuraJSBase<ItemJSBinding>::execute(args);
 	
-	if (!ret->isException() || g_vExtenderList.size() == 0)
+	if (!ret->isException() || g_vExtenderList.empty())
 		return ret;
 
 	g_ItemLock.lock();

--- a/src/static/util/code/UtilBZip2.cpp
+++ b/src/static/util/code/UtilBZip2.cpp
@@ -156,7 +156,7 @@ protected:
 		else
 			strm.next_in = &m_DataInStream[0];
 
-		if (m_bWriteEnd && strm.total_in_lo32 == 0 && strm.total_in_hi32 == 0 && m_DataInStream.size() == 0)
+		if (m_bWriteEnd && strm.total_in_lo32 == 0 && strm.total_in_hi32 == 0 && m_DataInStream.empty())
 		{
 			m_bEnd = true;
 			m_iLastError = BZ_STREAM_END;
@@ -200,7 +200,7 @@ protected:
 	{
 		const size_t buffsize = 10*1024;
 
-		if (m_bWriteEnd && strm.total_in_lo32 == 0 && strm.total_in_hi32 == 0 && m_DataInStream.size() == 0)
+		if (m_bWriteEnd && strm.total_in_lo32 == 0 && strm.total_in_hi32 == 0 && m_DataInStream.empty())
 		{
 			m_bEnd = true;
 			m_iLastError = BZ_STREAM_END;
@@ -227,7 +227,7 @@ protected:
 			}
 			else
 			{
-				if (m_bWriteEnd && m_DataInStream.size() == 0 && strm.total_out_hi32 == 0 && strm.total_out_lo32 == 0)
+				if (m_bWriteEnd && m_DataInStream.empty() && strm.total_out_hi32 == 0 && strm.total_out_lo32 == 0)
 					m_iLastError = BZ_STREAM_END;
 				
 				m_DataInStream.erase(m_DataInStream.begin(), m_DataInStream.end()-strm.avail_in);

--- a/src/static/util/code/UtilFsPath.cpp
+++ b/src/static/util/code/UtilFsPath.cpp
@@ -116,7 +116,7 @@ File Path::getFile() const
 
 std::string Path::getLastFolder() const
 {
-	if (m_vPath.size() == 0)
+	if (m_vPath.empty())
 		return "";
 
 	return m_vPath.back();
@@ -226,7 +226,7 @@ void Path::parsePath(std::string p, bool lastIsFolder)
 		m_vPath.erase(m_vPath.begin()+delList[x-1]);
 	}
 
-	if (lastIsFolder && m_vPath.size() > 0)
+	if (lastIsFolder && !m_vPath.empty())
 	{
 		m_File = File(m_vPath.back().c_str());
 		m_vPath.pop_back();

--- a/src/static/util/code/UtilFsPath.cpp
+++ b/src/static/util/code/UtilFsPath.cpp
@@ -36,9 +36,8 @@ File::File(const char* file)
 }
 
 File::File(std::string file)
-{
-	m_szFile = file;
-}
+:	m_szFile(file)
+{}
 
 std::string File::getFile() const
 {
@@ -103,14 +102,12 @@ Path::Path(std::string path, std::string file, bool lastIsFolder)
 }
 
 Path::Path(const Path& path)
-{
+:	m_File(path.getFile()),
+	m_vPath(path.m_vPath)
 #ifdef NIX
-	m_absolutePath = (path.getFullPath().size() > 0 && path.getFullPath()[0] == '/');
+	,m_absolutePath((path.getFullPath().size() > 0 && path.getFullPath()[0] == '/'))
 #endif
-
-	m_File = path.getFile();
-	m_vPath = path.m_vPath;
-}
+{}
 
 File Path::getFile() const
 {

--- a/src/static/util/code/UtilWeb.cpp
+++ b/src/static/util/code/UtilWeb.cpp
@@ -506,7 +506,7 @@ void HttpHInternal::setUpProxy()
 
 curl_slist_s* HttpHInternal::setUpHeaders()
 {
-	if (m_vHeaders.size() == 0)
+	if (m_vHeaders.empty())
 		return NULL;
 
 	curl_slist_s *headers = NULL;
@@ -608,7 +608,7 @@ uint8 HttpHInternal::postWeb()
 	curl_httppost *formPost = NULL; 
 	curl_httppost *formLast = NULL;
 
-	if (m_vFormPost.size() > 0)
+	if (!m_vFormPost.empty())
 	{
 		for (size_t x=0; x<m_vFormPost.size(); x++)
 			m_vFormPost[x]->addToPost(formPost, formLast);

--- a/src/static/util/code/UtilWindows_dotnet.cpp
+++ b/src/static/util/code/UtilWindows_dotnet.cpp
@@ -330,16 +330,16 @@ bool CheckNetfxBuildNumber(const char *pszNetfxRegKeyName, const char *pszNetfxR
 		// #.#.#####.##.  Try to parse the 4 parts of
 		// the version here
 
-		if (outList.size() >= 1 && outList[0].size() != 0)
+		if (!outList.empty() && !outList[0].empty())
 			iRegistryVersionMajor = atoi(outList[0].c_str());
 
-		if (outList.size() >= 2 && outList[1].size() != 0)
+		if (outList.size() >= 2 && !outList[1].empty())
 			iRegistryVersionMinor = atoi(outList[1].c_str());
 
-		if (outList.size() >= 3 && outList[2].size() != 0)
+		if (outList.size() >= 3 && !outList[2].empty())
 			iRegistryVersionBuild = atoi(outList[2].c_str());
 
-		if (outList.size() >= 4 && outList[3].size() != 0)
+		if (outList.size() >= 4 && !outList[3].empty())
 			iRegistryVersionRevision = atoi(outList[3].c_str());
 	}
 

--- a/src/static/util/code/UtilWindows_service.cpp
+++ b/src/static/util/code/UtilWindows_service.cpp
@@ -193,7 +193,7 @@ BOOL doStartService(SC_HANDLE Service, const char* szName, std::vector<std::stri
 {
 	BOOL res;
 
-	if (args.size() == 0)
+	if (args.empty())
 	{
 		res = StartService(Service, 0, NULL);
 	}

--- a/src/static/util_thread/code/ThreadPool.cpp
+++ b/src/static/util_thread/code/ThreadPool.cpp
@@ -195,7 +195,7 @@ void ThreadPool::run()
 
 		runTaskCount = activeThreads();
 
-		if ((runTaskCount == m_uiCount || m_vTaskList.size() == 0) && !isStopped())
+		if ((runTaskCount == m_uiCount || m_vTaskList.empty()) && !isStopped())
 			m_WaitCondition.wait();
 	}
 }
@@ -227,7 +227,7 @@ void ThreadPool::startNewTasks()
 
 	for (size_t x=0; x<m_vThreadList.size(); x++)
 	{
-		if (m_vTaskList.size() == 0)
+		if (m_vTaskList.empty())
 			break;
 
 		if (!m_vThreadList[x])
@@ -293,7 +293,7 @@ void ThreadPool::removedForced()
 {
 	m_ForcedMutex.writeLock();
 
-	if (m_vForcedList.size() > 0)
+	if (!m_vForcedList.empty())
 	{
 		std::vector<size_t> delVect;
 
@@ -334,7 +334,7 @@ BaseTask* ThreadPool::getTask()
 
 	m_TaskMutex.lock();
 
-	if (m_vTaskList.size() > 0)
+	if (!m_vTaskList.empty())
 	{
 		task = m_vTaskList.front();
 		m_vTaskList.pop_front();


### PR DESCRIPTION
This series of patches are moving member initialization into initialization list to aviod double setting of memvers.

```
Class
{
private:
  std::string str
public:
  Class()
  {
    str = "a String";
  }
}
```

will result into something like this (metacode):
1. alloc mem of Class
2. str = std::string()
3. entering constructore budy
4. str = std::("a String")

instead of setting member vars in the constructor body, we should move them out like this:

```
Class
{
private:
  std::string str
public:
  Class()
  :  str("a String")
  {}
}
```

this will result in this:
1. alloc mem of Class
2. str = std::string("a String")
3, entering constructore body (should be optimized out, because it is doing nothing)

This saves around 9kB of binary size with clang-3.1 on my system

Second thing I've done is replacing size() == 0 and size() > 0 calls with empty() and !empty(). size() could be linear complexitiy (depends on implementation), but empty() has always constant complexity.
