### PR TITLE
Adhere to OpenDesktop menu-spec

### DIFF
--- a/cmake/scripts/desura.desktop
+++ b/cmake/scripts/desura.desktop
@@ -1,8 +1,11 @@
 [Desktop Entry]
-Name=Desurium
+Version=1.0
 Type=Application
-Comment=Free software version of Desura game client
-Exec=@BIN_INSOURCE_DIR@/desura
-TryExec=@BIN_INSOURCE_DIR@/desura
-Icon=@DATA_INSOURCE_DIR@/desura.png
-Categories=Game;
+Name=Desurium
+GenericName=Digital games distribution client
+Comment=Free software version of Desura digital distribution client
+Exec=desura
+TryExec=desura
+Icon=desura
+Categories=Game;Amusement;
+Terminal=false


### PR DESCRIPTION
If the `.desktop` file is invalid according to http://standards.freedesktop.org/desktop-entry-spec/1.0/ it will break rpm on http://build.opensuse.org

```
ERROR: No sufficient Category definition: /home/abuild/rpmbuild/BUILDROOT/Desurium-0.8.0_rc4-0.i386//usr/share/applications/desura.desktop 
WARNING: file extension in Icon line: /home/abuild/rpmbuild/BUILDROOT/Desurium-0.8.0_rc4-0.i386//usr/share/applications/desura.desktop
ERROR: Icon file not installed: /home/abuild/rpmbuild/BUILDROOT/Desurium-0.8.0_rc4-0.i386//usr/share/applications/desura.desktop (../../share/desurium/desura.png)
WARNING: Empty GenericName: /home/abuild/rpmbuild/BUILDROOT/Desurium-0.8.0_rc4-0.i386//usr/share/applications/desura.desktop
Errors in installed desktop file detected. Please refer to http://en.opensuse.org/SUSE_Package_Conventions/RPM_Macros
error: Bad exit status from /var/tmp/rpm-tmp.4K6kkj (%install)
```

This should fix it.
