### PR TITLE
Default 32bit support on 64bit Linux

### DIFF
--- a/README
+++ b/README
@@ -46,10 +46,6 @@ tinyxml
 
 Finally run Desura using ./install/desura
 
-If you're on a 64bit system and want 32bit support, abort building it and go to
-the 'build' folder, and edit the CMake cache as to enable 32BIT_SUPPORT.
-(You can use ccmake or cmake-gui for this).
-
 Build Desura on Windows
 =====================
 

--- a/cmake/platform/unix/platform.cmake
+++ b/cmake/platform/unix/platform.cmake
@@ -40,9 +40,19 @@ endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(64BIT TRUE)
-  message("-- detected 64bit")
-  
-  option(32BIT_SUPPORT "enable support for 32bit applications (requires 32bit libraries)" ON)
+  message("-- Detected 64bit")
+  try_compile(MULTILIB_TEST_COMPILE
+    "${CMAKE_TEST_PROJECTS_BIN}/multilib_test"
+    "${CMAKE_TEST_PROJECTS}/multilib_test"
+    "multilib_test"
+    "multilib_test")
+  if(MULTILIB_TEST_COMPILE)
+    message("-- Working multilib, enable 32bit support")
+    option(32BIT_SUPPORT "enable support for 32bit applications (requires 32bit libraries)" ON)
+  else()
+    message("-- Not working multilib, disable 32bit support")
+    option(32BIT_SUPPORT "enable support for 32bit applications (requires 32bit libraries)" OFF)
+  endif()
 else()
   set(64BIT FALSE)
   message("-- detected 32bit")

--- a/cmake/platform/unix/platform.cmake
+++ b/cmake/platform/unix/platform.cmake
@@ -42,7 +42,7 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(64BIT TRUE)
   message("-- detected 64bit")
   
-  option(32BIT_SUPPORT "enable support for 32bit applications (requires 32bit libraries)" OFF)
+  option(32BIT_SUPPORT "enable support for 32bit applications (requires 32bit libraries)" ON)
 else()
   set(64BIT FALSE)
   message("-- detected 32bit")

--- a/cmake/tests/multilib_test/CMakeLists.txt
+++ b/cmake/tests/multilib_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8)
+project(multilib_test)
+set(CMAKE_C_FLAGS "-m32")
+file(GLOB Sources *.c)
+
+add_executable(multilib_test ${Sources})

--- a/cmake/tests/multilib_test/multilib_test.c
+++ b/cmake/tests/multilib_test/multilib_test.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main (void)
+{
+   puts ("Testing multilib capabilities");
+   return 0;
+}


### PR DESCRIPTION
I guess that most gamers on 64 bit system want their 32 bit games to work by default. install-deps.sh already provides all dependencies for building this support (at least on Ubuntu and Debian).
