### PR TITLE
use systemwide xdg-open and clean up URL whitelist

### DIFF
--- a/src/executable/bootloader_lin/code/DesuraMain.cpp
+++ b/src/executable/bootloader_lin/code/DesuraMain.cpp
@@ -108,7 +108,7 @@ void ShowHelpDialog(const char* msg, const char* url, const char* type)
 	
 	if (url)
 	{
-		std::string systemString("xdg/xdg-open ");
+		std::string systemString("xdg-open ");
 		systemString += url;
 		
 		system(systemString.c_str());

--- a/src/shared/uicore/code/MainApp.cpp
+++ b/src/shared/uicore/code/MainApp.cpp
@@ -125,6 +125,8 @@ const char* g_szSafeList[] =
 	"desura.com",
 	".paypal.com",
 	"paypal.com",
+	".google.com",
+	"google.com",
 	".addthis.com",
 	"addthis.com",
 	".gameura.com",

--- a/src/shared/uicore/code/MainApp.cpp
+++ b/src/shared/uicore/code/MainApp.cpp
@@ -127,17 +127,6 @@ const char* g_szSafeList[] =
 	"paypal.com",
 	".google.com",
 	"google.com",
-	".addthis.com",
-	"addthis.com",
-	".gameura.com",
-	"gameura.com",
-
-#ifdef DEBUG
-	"gamedev.com",
-	".gamedev.com",
-	"erunways.com",
-#endif
-
 	NULL,
 };
 

--- a/src/shared/usercore/code/User.cpp
+++ b/src/shared/usercore/code/User.cpp
@@ -369,7 +369,7 @@ void User::onNeedWildCardCB(WCSpecialInfo& info)
 #else
 	if (Safe::stricmp("XDG_OPEN", info.name.c_str()) == 0)
 	{
-		info.result = gcString(UTIL::OS::getCurrentDir(L"xdg/xdg-open"));
+		info.result = gcString(UTIL::OS::getCurrentDir(L"xdg-open"));
 		info.handled = true;
 	}
 #endif

--- a/src/static/util/code/UtilLinux.cpp
+++ b/src/static/util/code/UtilLinux.cpp
@@ -510,12 +510,9 @@ bool launchProcessXDG(const char* exe, const char* libPath)
 
 	ERROR_OUTPUT("Launching with xdg-open");
 	execlp("xdg-open", "xdg-open", fullExe.c_str(), NULL);
-
-	ERROR_OUTPUT("Must have failed. Launching with gnome-open");
-	execlp("gnome-open", "gnome-open", fullExe.c_str(), NULL);
 	
 	//um shit. We shouldnt be here. :(
-	printf("Failed to exec gnome-open or xdg-open for %s. Error: %d\n", fullExe.c_str(), errno);
+	printf("Failed to exec xdg-open for %s. Error: %d\n", fullExe.c_str(), errno);
 	exit(-1);
 	return false;
 }
@@ -544,7 +541,6 @@ bool launchFolder(const char* path)
 	setenv("LD_LIBRARY_PATH", "", 1);
 
 	execlp("xdg-open", "xdg-open", fullPath.c_str(), NULL);
-	execlp("gnome-open", "gnome-open", fullPath.c_str(), NULL);
 	
 	//um shit. We shouldnt be here. :(
 	printf("Failed to execlp %s. Error: %d\n", fullPath.c_str(), errno);

--- a/src/static/util/code/UtilLinux.cpp
+++ b/src/static/util/code/UtilLinux.cpp
@@ -509,7 +509,7 @@ bool launchProcessXDG(const char* exe, const char* libPath)
 	(void)chdir(wd.c_str());
 
 	ERROR_OUTPUT("Launching with xdg-open");
-	execlp("xdg/xdg-open", "xdg/xdg-open", fullExe.c_str(), NULL);
+	execlp("xdg-open", "xdg-open", fullExe.c_str(), NULL);
 
 	ERROR_OUTPUT("Must have failed. Launching with gnome-open");
 	execlp("gnome-open", "gnome-open", fullExe.c_str(), NULL);
@@ -543,7 +543,7 @@ bool launchFolder(const char* path)
 
 	setenv("LD_LIBRARY_PATH", "", 1);
 
-	execlp("xdg/xdg-open", "xdg/xdg-open", fullPath.c_str(), NULL);
+	execlp("xdg-open", "xdg-open", fullPath.c_str(), NULL);
 	execlp("gnome-open", "gnome-open", fullPath.c_str(), NULL);
 	
 	//um shit. We shouldnt be here. :(


### PR DESCRIPTION
desura used to bundle all xdg tools in the binary distribution. But we want to use the system wide installed ones

fixes #531

NOTE: fe8ff527c36ece7384a0329470e3e0932bcc8c63 and 828541ab52122eef548a3d76048d7c4e400bf076 are candidates for the stable branch
