### PR TITLE
travis: use 64bit wxGTK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@ language: cpp
 compiler: gcc
 before_install:
   - sudo apt-get install libnotify-dev libtinyxml-dev libv8-dev libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-thread-dev libboost-system-dev libboost-test-dev
-  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-dev_2.9.3-1_i386.deb"
-  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/wx2.9-headers_2.9.3-1_i386.deb"
-  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-0_2.9.3-1_i386.deb"
-  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxbase2.9-dev_2.9.3-1_i386.deb"
-  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxbase2.9-0_2.9.3-1_i386.deb"
-  - sudo dpkg --install libwxbase2.9-0_2.9.3-1_i386.deb
-  - sudo dpkg --install libwxgtk2.9-0_2.9.3-1_i386.deb
-  - sudo dpkg --install wx2.9-headers_2.9.3-1_i386.deb
-  - sudo dpkg --install libwxbase2.9-dev_2.9.3-1_i386.deb
-  - sudo dpkg --install libwxgtk2.9-dev_2.9.3-1_i386.deb
+  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-dev_2.9.3-1_amd64.deb"
+  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/wx2.9-headers_2.9.3-1_amd64.deb"
+  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-0_2.9.3-1_amd64.deb"
+  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxbase2.9-dev_2.9.3-1_amd64.deb"
+  - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxbase2.9-0_2.9.3-1_amd64.deb"
+  - sudo dpkg --install libwxbase2.9-0_2.9.3-1_amd64.deb
+  - sudo dpkg --install libwxgtk2.9-0_2.9.3-1_amd64.deb
+  - sudo dpkg --install wx2.9-headers_2.9.3-1_amd64.deb
+  - sudo dpkg --install libwxbase2.9-dev_2.9.3-1_amd64.deb
+  - sudo dpkg --install libwxgtk2.9-dev_2.9.3-1_amd64.deb
 before_script:
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 compiler: gcc
 before_install:
-  - sudo apt-get install libnotify-dev libtinyxml-dev libv8-dev libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-thread-dev libboost-system-dev libboost-test-dev
+  - sudo apt-get install gcc-multilib libnotify-dev libtinyxml-dev libv8-dev libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-thread-dev libboost-system-dev libboost-test-dev
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-dev_2.9.3-1_amd64.deb"
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/wx2.9-headers_2.9.3-1_amd64.deb"
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-0_2.9.3-1_amd64.deb"


### PR DESCRIPTION
travis-ci moved to 64bit. http://about.travis-ci.org/blog/august-2012-upcoming-ci-environment-updates/

fixes travis-ci build errors
