### PR TITLE
js/playList: parse rating to float

### DIFF
--- a/build_out/data/themes/default/js/play.list.js
+++ b/build_out/data/themes/default/js/play.list.js
@@ -69,10 +69,14 @@ sortList = function(list) {
 
 		for(item in list) {
 			try {
-				temp[item] = {key: item, value: eval("list[item]."+sortFieldCache+"()")};
+				temp[item] = {key: item, value: list[item][sortFieldCache]()};
 				
 				if (typeof(temp[item].value) == 'string')
 					temp[item].value = temp[item].value.toLowerCase();
+				// rating is the only float attribute, but every attribute is 
+				// typed as a string
+				if (sortFieldCache == 'getRating')
+					temp[item].value = parseFloat(temp[item].value);
 				
 			} catch(e) {}
 		}


### PR DESCRIPTION
the custom sort function is comparing strings. String comparision in JavaScript is fine as long as both strings have the same lenght and the decimal mark at the same position.

But "10.0" was the only case violating this. "10.0" < a is returning false for all a's matching ^[0-9].[0-9]$

fixes #374

NOTE: this is a candidate for the stable branch

v2: we need to handle the rating coloumn explicitly, also remove this dirty eval hack with an associative array access
