### PR TITLE
cmake/platform/unix: add boost-1.53 no scoped enum definition

### DIFF
--- a/cmake/platform/unix/platform.cmake
+++ b/cmake/platform/unix/platform.cmake
@@ -2,9 +2,11 @@
 # some global defines
 ###############################################################################
 
+# boost-1.53 changed the variable to disable native scoped enum detection
 add_definitions(
   -DBOOST_FILESYSTEM_VERSION=3
   -DBOOST_NO_SCOPED_ENUMS=1
+  -DBOOST_NO_CXX11_SCOPED_ENUMS=1
   -D_LARGE_FILES
   -D_FILE_OFFSET_BITS=64
 )


### PR DESCRIPTION
this will fix every linking error caused by using API with a boost emulated scoped enum emulation under boost-1.53 (currently only boost::filesystem::copy_file).

We have to forcing scoped enum emulation, because distributions will compile boost against the c++03 ABI and we are using the c++11 ABI. On the first one, boost is emulation scoped enums with namespaces on the latter it will use the natives one resulting into incompatible APIs.

fixes #533

NOTE: this is a candidate for the stable branch
