### PR TITLE
cmake: rework unit test execution a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(NOT BUILD_ONLY_CEF)
     set(Boost_ADDITION_LIBS ${Boost_ADDITION_LIBS} chrono)
   endif()
   if(BUILD_TESTS)
-    set(Boost_ADDITION_LIBS ${Boost_ADDITION_LIBS} test_exec_monitor unit_test_framework)
+    set(Boost_ADDITION_LIBS ${Boost_ADDITION_LIBS} unit_test_framework)
   endif()
   
   set(Boost_USE_MULTITHREADED ON)

--- a/cmake/modules/macros.cmake
+++ b/cmake/modules/macros.cmake
@@ -95,6 +95,8 @@ macro(add_desura_test name category neededLibs)
                           ${CMAKE_SOURCE_DIR}/src/tests/${category}/${name}*.h
                           ${CMAKE_SOURCE_DIR}/src/tests/*.h)
     add_executable(${name} ${${name}_SRC})
+    # have to be defined to generate a main function
+    add_definitions(-DBOOST_TEST_DYN_LINK)
     include_directories(
       ${CMAKE_SOURCE_DIR}/src/tests
       ${Boost_INCLUDE_DIR}
@@ -102,7 +104,6 @@ macro(add_desura_test name category neededLibs)
     target_link_libraries(${name}
       ${neededLibs}
       ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-      ${Boost_TEST_EXEC_MONITOR_LIBRARY}
     )
     add_test(${name} ${CMAKE_BINARY_DIR}/src/tests/${name})
   endif()


### PR DESCRIPTION
so we don't depend on the static test_exec_monitor boost lib, also fixes some rare main undefined errors

NOTE: this is a candidate for the stable branch
