### PR TITLE
patch/chromium-nss-3.15: check against major version as well

### DIFF
--- a/cmake/patches/chromium-nss-3.15.patch
+++ b/cmake/patches/chromium-nss-3.15.patch
@@ -5,7 +5,7 @@
  void ParsePrincipal(CERTName* name,
                      CertPrincipal* principal) {
 -  typedef char* (*CERTGetNameFunc)(CERTName* name);
-+  #if NSS_VMINOR >= 15
++  #if NSS_VMAJOR >= 3 && NSS_VMINOR >= 15
 +    typedef char* (*CERTGetNameFunc)(CERTName const* name);
 +  #else
 +    typedef char* (*CERTGetNameFunc)(CERTName* name);


### PR DESCRIPTION
we should do it this way, just to be more clean
