### PR TITLE
usercore,servicecore: fix loading of scriptcore.dll

### DIFF
--- a/src/shared/servicecore/code/InstallScriptRunTime.cpp
+++ b/src/shared/servicecore/code/InstallScriptRunTime.cpp
@@ -168,10 +168,10 @@ public:
 protected:
 	bool loadDll()
 	{
-#ifndef DEBUG
+#if !defined(DEBUG) && defined(DESURA_OFFICAL_BUILD)
 	#ifdef WIN32
 			char message[255] = {0};
-			if (UTIL::WIN::validateCert(L".\\bin\\scriptcore.dll", message, 255) != ERROR_SUCCESS)
+			if (UTIL::WIN::validateCert(L".\\scriptcore.dll", message, 255) != ERROR_SUCCESS)
 			{
 				Warning(gcString("Cert validation failed on scriptcore.dll: {0}\n", message));
 				return false;
@@ -180,13 +180,8 @@ protected:
 #endif
 
 #ifdef WIN32
-	#ifdef DEBUG
-			if (!m_ScriptCore.load("scriptcore-d.dll"))
-				return false;
-	#else
-			if (!m_ScriptCore.load("scriptcore.dll"))
-				return false;
-	#endif
+		if (!m_ScriptCore.load("scriptcore.dll"))
+			return false;
 #else
 		if (!m_ScriptCore.load("libscriptcore.so"))
 			return false;

--- a/src/shared/usercore/code/ToolManager_Script.cpp
+++ b/src/shared/usercore/code/ToolManager_Script.cpp
@@ -319,13 +319,8 @@ bool ToolManager::initJSEngine()
 bool ToolManager::loadJSEngine()
 {
 #ifdef WIN32
-#ifdef DEBUG
-	if (!m_ScriptCore.load("scriptcore-d.dll"))
-		return false;
-#else
 	if (!m_ScriptCore.load("scriptcore.dll"))
 		return false;
-#endif
 #else
 	if (!m_ScriptCore.load("libscriptcore.so"))
 		return false;


### PR DESCRIPTION
I forgot this in the win32 pull request, it just fixes the loading of the scriptcore.dll which is not really required anyway.
