### PR TITLE
threads: fix thread_interrupted exception

### DIFF
--- a/src/static/util_thread/code/BaseThread.cpp
+++ b/src/static/util_thread/code/BaseThread.cpp
@@ -330,7 +330,11 @@ void BaseThread::stop()
 		m_pPrivates->m_pThread->interrupt();
 		if (m_pPrivates->m_pThread->joinable())
 		{
-			m_pPrivates->m_pThread->join();
+			try {
+				m_pPrivates->m_pThread->join();
+			} catch (boost::thread_interrupted &e) {
+				// thread was interrupted, which is fine for us here
+			}
 		}
 	}
 }


### PR DESCRIPTION
When quitting desurium we are running into this problem, because we want to join a thread, which gets interrupted.

NOTE: this is a candidate for the stable branch
