### PR TITLE
add copyright notes to changed source files

### DIFF
--- a/build_out/data/bindings/host_binding.js
+++ b/build_out/data/bindings/host_binding.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/installer_binding_fs.js
+++ b/build_out/data/bindings/installer_binding_fs.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/installer_binding_item.js
+++ b/build_out/data/bindings/installer_binding_item.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/installer_binding_item_service.js
+++ b/build_out/data/bindings/installer_binding_item_service.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/installer_binding_item_user.js
+++ b/build_out/data/bindings/installer_binding_item_user.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/installer_binding_os.js
+++ b/build_out/data/bindings/installer_binding_os.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding.js
+++ b/build_out/data/bindings/native_binding.js
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_branchinfo.js
+++ b/build_out/data/bindings/native_binding_branchinfo.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_events.js
+++ b/build_out/data/bindings/native_binding_events.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_iteminfo.js
+++ b/build_out/data/bindings/native_binding_iteminfo.js
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_links.js
+++ b/build_out/data/bindings/native_binding_links.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_settings.js
+++ b/build_out/data/bindings/native_binding_settings.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_uploadinfo.js
+++ b/build_out/data/bindings/native_binding_uploadinfo.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/bindings/native_binding_userinfo.js
+++ b/build_out/data/bindings/native_binding_userinfo.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/css/reset.css
+++ b/build_out/data/themes/default/css/reset.css
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 /* -------------------------------------------------------------- 
   
    Reset.css

--- a/build_out/data/themes/default/css/screen.css
+++ b/build_out/data/themes/default/css/screen.css
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 /* -------------------------------------------------------------- 
 
 	 Page style

--- a/build_out/data/themes/default/css/scrollbar.css
+++ b/build_out/data/themes/default/css/scrollbar.css
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 ::-webkit-scrollbar {
 	width: 21px;
     height: 21px;

--- a/build_out/data/themes/default/css/tipsy.css
+++ b/build_out/data/themes/default/css/tipsy.css
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 .tipsy {
 	padding: 5px; 
 	font-size: 11px; 

--- a/build_out/data/themes/default/css/ui.achtung.css
+++ b/build_out/data/themes/default/css/ui.achtung.css
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 /* IE 6 doesn't support position: fixed */
 * html #achtung-overlay {
 	position:absolute;

--- a/build_out/data/themes/default/html/error.html
+++ b/build_out/data/themes/default/html/error.html
@@ -1,7 +1,7 @@
 <!--
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/html/loading.html
+++ b/build_out/data/themes/default/html/loading.html
@@ -1,7 +1,7 @@
 <!--
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/html/playlist.html
+++ b/build_out/data/themes/default/html/playlist.html
@@ -1,15 +1,20 @@
 <!--
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Telemaniaka <telemaniaka@gmail.com>
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */

--- a/build_out/data/themes/default/html/settings.html
+++ b/build_out/data/themes/default/html/settings.html
@@ -1,7 +1,7 @@
 <!--
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/functions_lin.js
+++ b/build_out/data/themes/default/js/functions_lin.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/functions_win.js
+++ b/build_out/data/themes/default/js/functions_win.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/play.items.js
+++ b/build_out/data/themes/default/js/play.items.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/play.list.js
+++ b/build_out/data/themes/default/js/play.list.js
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/play.menu.js
+++ b/build_out/data/themes/default/js/play.menu.js
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/play.setup.js
+++ b/build_out/data/themes/default/js/play.setup.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/settings_lin.js
+++ b/build_out/data/themes/default/js/settings_lin.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/build_out/data/themes/default/js/settings_win.js
+++ b/build_out/data/themes/default/js/settings_win.js
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/find_missing_copyright_notes.sh
+++ b/find_missing_copyright_notes.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 repair_corrupted=""
-excluded_commits=""
+excluded_commits="926f560d8e3abbd1a587d012891e8d0bda199549"
 excluded_emails=""
 name_substitutions="
 	karolherbst:Karol Herbst

--- a/find_missing_copyright_notes.sh
+++ b/find_missing_copyright_notes.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+repair_corrupted=""
+excluded_commits=""
+excluded_emails=""
+name_substitutions="
+	karolherbst:Karol Herbst
+	Smilex:Ian T. Jacobsen
+"
+email_substitutions="
+	lodle,mark@desura.com:Mark Chandler,mark@moddb.com
+	mark,mark@ubuntu.(none):Mark Chandler,mark@moddb.com
+	linux64,mark@ubuntu.(none):Mark Chandler,mark@moddb.com
+"
+
+license_header_begin="/\*
+Desura is the leading indie game distribution platform"
+
+license_header_end="This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+\(at your option\) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+\*/"
+
+# first we have to find every C style source file, we will do xml, html files later
+find src/ build_out/ -type f -not -path "*/RES/*" -not -path "*src/branding_desur*" -not -path "*/third_party/*" -not -iname "*jquery*.js" -not -iname "*.crt" \( -iname "*.c*" -or -iname "*.h*" -or -iname "*.js*" -or -iname "*.css*" -or -iname "*.html*" \) | while read file; do
+
+	printf "processing file: $file\n"
+
+	# first we check if the file has a proper license header
+	# the regex for the copyright must match something like: Copyright (C) 2011-2013,2015 Name Surname <email.adress@provider.com>\n
+	# though we don't save the year information yet
+	header=$(pcregrep -M "$license_header_begin[\n]*Copyright [a-zA-Z0-9<>@() :.,/\-\n]*$license_header_end" $file)
+	# if we don't get a match, print the error out
+	corrupted=""
+	if [ -z "$header" ]; then
+		printf "$file: license header missing or corrupted\n" 1>&2
+		if [ -z "$repair_corrupted" ]; then
+			continue
+		fi
+		corrupted="yes"
+	fi
+
+	# add the rest of the license text
+	end_of_license_found=""
+	cat $file | while IFS= read -r file_line || [ -n "$file_line" ]; do
+		if [ -n "$end_of_license_found" ]; then
+			printf "%s\n" "$file_line">> $file
+			continue
+		fi
+
+		# if corrupted we just start at the beginngn and throw out an error
+		if [ "$file_line" = "*/" ] || [ -n "$corrupted" ]; then
+			if [ -n "$corrupted" ]; then
+				printf "$file: was corrupted and yet repaired\n" 1>&2
+			fi
+			end_of_license_found="found"
+
+			# first clear the file
+			printf "" > "$file"
+
+			if [ $(echo "$file" | awk -F . '{print $NF}') = html ]; then
+				printf "<!--\n" >> "$file"
+			fi
+
+			# first write the license header into the file
+			printf "$license_header_begin" | sed 's/\\//g' >> "$file"
+
+			# now we just have to give us the formatted name <email> commit tag
+			first=""
+			commits=$(git log --no-merges --pretty=format:"%H:%an <%ae>" $file)
+			for ec in $excluded_commits; do
+				commits=$(printf "$commits" | sed "/$ec/d")
+			done
+			for email in $excluded_emails; do
+				commits=$(printf "$commits" | sed "/$email/d")
+			done
+
+			# replace first commit
+			commits=$(printf "$commits" | sed 's/6d1adee39a76a88e5bf2b877f61a83a5b0eced51:Mark Chandler <mark@moddb.com>/6d1adee39a76a88e5bf2b877f61a83a5b0eced51:Desura Ltd. <support@desura.com>/g')
+
+			# substitutes
+			commits=$(
+				printf "$name_substitutions" | {
+					while read -r subst; do
+						if [ -z "$subst" ]; then
+							continue
+						fi
+						old=$(printf "$subst" | cut -d: -f1)
+						new=$(printf "$subst" | cut -d: -f2)
+						commits=$(printf "$commits" | sed "s/$old /$new /g")
+					done
+					printf "$commits"
+				}
+			)
+			commits=$(
+				printf "$email_substitutions" | {
+					while read subst; do
+						if [ -z "$subst" ]; then
+							continue
+						fi
+						old=$(printf "$subst" | cut -d: -f1 )
+						oldname=$(printf "$old" | cut -d, -f1 )
+						oldemail=$(printf "$old" | cut -d, -f2 )
+						new=$(printf "$subst" | cut -d: -f2 )
+						newname=$(printf "$new" | cut -d, -f1 )
+						newemail=$(printf "$new" | cut -d, -f2 )
+
+						commits=$(echo "$commits" | sed "s/$oldname <$oldemail>/$newname <$newemail>/g")
+					done
+					printf "$commits"
+				}
+			)
+
+			printf "$commits" | sort -u --key=1.41 | while read -r author; do
+				# and write our copyright string
+				if [ -z "$first" ]; then
+					printf "\nCopyright " >> "$file"
+					first="true"
+				else
+					printf "\n          " >> "$file"
+				fi
+
+				author=$(printf "$author" | cut -d: -f2)
+				printf "(C) $author" >> "$file"
+			done
+			printf "\n\n$license_header_end\n" | sed 's/\\//g' >> "$file"
+		fi
+	done
+
+done
+

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/LogBones.cpp
+++ b/src/common/LogBones.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/LogBones.h
+++ b/src/common/LogBones.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/browser_pipe/IPCBrowser.cpp
+++ b/src/common/browser_pipe/IPCBrowser.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/browser_pipe/IPCBrowser.h
+++ b/src/common/browser_pipe/IPCBrowser.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/gcJSBase.cpp
+++ b/src/common/gcJSBase.cpp
@@ -1,13 +1,22 @@
-///////////// Copyright © 2010 Desura Pty Ltd. All rights reserved.  /////////////
-//
-//   Project     : uicore
-//   File        : gcJSBase.cpp
-//   Description :
-//      [TODO: Write the purpose of gcJSBase.cpp.]
-//
-//   Created On: 6/17/2010 10:53:04 AM
-//   Created By: Mark Chandler <mailto:mark@moddb.com>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "gcJSBase.h"

--- a/src/common/gcJSBase.h
+++ b/src/common/gcJSBase.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCComplexLaunch.cpp
+++ b/src/common/service_pipe/IPCComplexLaunch.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCComplexLaunch.h
+++ b/src/common/service_pipe/IPCComplexLaunch.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCInstallMcf.cpp
+++ b/src/common/service_pipe/IPCInstallMcf.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCInstallMcf.h
+++ b/src/common/service_pipe/IPCInstallMcf.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCServiceMain.cpp
+++ b/src/common/service_pipe/IPCServiceMain.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCServiceMain.h
+++ b/src/common/service_pipe/IPCServiceMain.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUninstallBranch.cpp
+++ b/src/common/service_pipe/IPCUninstallBranch.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUninstallBranch.h
+++ b/src/common/service_pipe/IPCUninstallBranch.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUninstallMcf.cpp
+++ b/src/common/service_pipe/IPCUninstallMcf.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUninstallMcf.h
+++ b/src/common/service_pipe/IPCUninstallMcf.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUpdateApp.cpp
+++ b/src/common/service_pipe/IPCUpdateApp.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/service_pipe/IPCUpdateApp.h
+++ b/src/common/service_pipe/IPCUpdateApp.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/tool_pipe/IPCToolMain.cpp
+++ b/src/common/tool_pipe/IPCToolMain.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/common/tool_pipe/IPCToolMain.h
+++ b/src/common/tool_pipe/IPCToolMain.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bittest/code/main.c
+++ b/src/executable/bittest/code/main.c
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_lin/code/DesuraMain.cpp
+++ b/src/executable/bootloader_lin/code/DesuraMain.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_lin/code/DesuraMain.h
+++ b/src/executable/bootloader_lin/code/DesuraMain.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_lin/code/UtilFile.cpp
+++ b/src/executable/bootloader_lin/code/UtilFile.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_lin/code/UtilFile.h
+++ b/src/executable/bootloader_lin/code/UtilFile.h
@@ -1,7 +1,6 @@
-
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/AppUpdateInstall.cpp
+++ b/src/executable/bootloader_win/code/AppUpdateInstall.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/AppUpdateInstall.h
+++ b/src/executable/bootloader_win/code/AppUpdateInstall.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/DesuraMain.cpp
+++ b/src/executable/bootloader_win/code/DesuraMain.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/DesuraMainMingw.cpp
+++ b/src/executable/bootloader_win/code/DesuraMainMingw.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2012 Karol Herbst
+Copyright (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/Log.cpp
+++ b/src/executable/bootloader_win/code/Log.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/UpdateFunctions.cpp
+++ b/src/executable/bootloader_win/code/UpdateFunctions.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/UpdateFunctions.h
+++ b/src/executable/bootloader_win/code/UpdateFunctions.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/stdafx.cpp
+++ b/src/executable/bootloader_win/code/stdafx.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/bootloader_win/code/stdafx.h
+++ b/src/executable/bootloader_win/code/stdafx.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/crashdlg_lin/code/main.cpp
+++ b/src/executable/crashdlg_lin/code/main.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefBrowserLoader.cpp
+++ b/src/executable/desura_browserhost/code/CefBrowserLoader.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefEvents.cpp
+++ b/src/executable/desura_browserhost/code/CefEvents.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefEvents.h
+++ b/src/executable/desura_browserhost/code/CefEvents.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefEvents_Js.cpp
+++ b/src/executable/desura_browserhost/code/CefEvents_Js.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefSchemeBase.h
+++ b/src/executable/desura_browserhost/code/CefSchemeBase.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefThemeLoader.cpp
+++ b/src/executable/desura_browserhost/code/CefThemeLoader.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/CefThemeLoader.h
+++ b/src/executable/desura_browserhost/code/CefThemeLoader.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/desura_browserhost/code/HostMain.cpp
+++ b/src/executable/desura_browserhost/code/HostMain.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/service_win/code/ServiceMain.cpp
+++ b/src/executable/service_win/code/ServiceMain.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/service_win/code/ServiceMain.h
+++ b/src/executable/service_win/code/ServiceMain.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/service_win/code/ServiceUtil.cpp
+++ b/src/executable/service_win/code/ServiceUtil.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/service_win/code/main.cpp
+++ b/src/executable/service_win/code/main.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/service_win/code/resource.h
+++ b/src/executable/service_win/code/resource.h
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by MidSvc.rc

--- a/src/executable/toolhelper/code/main.cpp
+++ b/src/executable/toolhelper/code/main.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/toolhelper/code/stdafx.cpp
+++ b/src/executable/toolhelper/code/stdafx.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/toolhelper/code/stdafx.h
+++ b/src/executable/toolhelper/code/stdafx.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/utilhelper/code/main.cpp
+++ b/src/executable/utilhelper/code/main.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/utilhelper/code/stdafx.cpp
+++ b/src/executable/utilhelper/code/stdafx.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/executable/utilhelper/code/stdafx.h
+++ b/src/executable/utilhelper/code/stdafx.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/BZip2.h
+++ b/src/include/BZip2.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/BaseManager.h
+++ b/src/include/BaseManager.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/Color.h
+++ b/src/include/Color.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/DesuraId.h
+++ b/src/include/DesuraId.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/Event.h
+++ b/src/include/Event.h
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/IPCServerI.h
+++ b/src/include/IPCServerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/LogCallback.h
+++ b/src/include/LogCallback.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/MainAppI.h
+++ b/src/include/MainAppI.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/MiniDumpGenerator.h
+++ b/src/include/MiniDumpGenerator.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/ScriptCoreI.h
+++ b/src/include/ScriptCoreI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/ServiceCoreI.h
+++ b/src/include/ServiceCoreI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/SharedObjectLoader.h
+++ b/src/include/SharedObjectLoader.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/UICoreI.h
+++ b/src/include/UICoreI.h
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 Desura Pty Ltd. All rights reserved. /////////////
-//
-//   Project     : uicore
-//   File        : uicore.h
-//   Description :
-//      [TODO: Write the purpose of uicore.h.]
-//
-//   Created On: 9/27/2009 3:58:27 PM
-//   Created By: Mark Chandler <mailto:mark@moddb.com>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #ifndef DESURA_UICORE_H
 #define DESURA_UICORE_H

--- a/src/include/UtilBootloader.h
+++ b/src/include/UtilBootloader.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/XMLMacros.h
+++ b/src/include/XMLMacros.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/gcError.h
+++ b/src/include/gcError.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/managers/CVar.h
+++ b/src/include/managers/CVar.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/managers/ConCommand.h
+++ b/src/include/managers/ConCommand.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/managers/Managers.h
+++ b/src/include/managers/Managers.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/managers/WildcardDelegate.h
+++ b/src/include/managers/WildcardDelegate.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/managers/WildcardManager.h
+++ b/src/include/managers/WildcardManager.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/DownloadProvider.h
+++ b/src/include/mcfcore/DownloadProvider.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/MCFDPReporterI.h
+++ b/src/include/mcfcore/MCFDPReporterI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/MCFFileI.h
+++ b/src/include/mcfcore/MCFFileI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/MCFHeaderI.h
+++ b/src/include/mcfcore/MCFHeaderI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/MCFI.h
+++ b/src/include/mcfcore/MCFI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/MCFMain.h
+++ b/src/include/mcfcore/MCFMain.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/ProgressInfo.h
+++ b/src/include/mcfcore/ProgressInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/mcfcore/UserCookies.h
+++ b/src/include/mcfcore/UserCookies.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/CustomInstallPathSql.h
+++ b/src/include/sql/CustomInstallPathSql.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/GameExplorerSql.h
+++ b/src/include/sql/GameExplorerSql.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/ItemInfoSql.h
+++ b/src/include/sql/ItemInfoSql.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/McfUploadSql.h
+++ b/src/include/sql/McfUploadSql.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/ToolManagerSql.h
+++ b/src/include/sql/ToolManagerSql.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/sql/WebCoreSql.h
+++ b/src/include/sql/WebCoreSql.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/umcf/UMcf.h
+++ b/src/include/umcf/UMcf.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/umcf/UMcfFile.h
+++ b/src/include/umcf/UMcfFile.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/umcf/UMcfHeader.h
+++ b/src/include/umcf/UMcfHeader.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/BranchInfoI.h
+++ b/src/include/usercore/BranchInfoI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/CDKeyManagerI.h
+++ b/src/include/usercore/CDKeyManagerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/CIPInfo.h
+++ b/src/include/usercore/CIPInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/CIPManagerI.h
+++ b/src/include/usercore/CIPManagerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/DownloadInfo.h
+++ b/src/include/usercore/DownloadInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/GuiDownloadProvider.h
+++ b/src/include/usercore/GuiDownloadProvider.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/InstallInfoI.h
+++ b/src/include/usercore/InstallInfoI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/ItemHandleI.h
+++ b/src/include/usercore/ItemHandleI.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/ItemHelpersI.h
+++ b/src/include/usercore/ItemHelpersI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/ItemInfoI.h
+++ b/src/include/usercore/ItemInfoI.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/ItemManagerI.h
+++ b/src/include/usercore/ItemManagerI.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/MCFThreadI.h
+++ b/src/include/usercore/MCFThreadI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/NewsItem.h
+++ b/src/include/usercore/NewsItem.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/ToolManagerI.h
+++ b/src/include/usercore/ToolManagerI.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UploadInfo.h
+++ b/src/include/usercore/UploadInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UploadInfoThreadI.h
+++ b/src/include/usercore/UploadInfoThreadI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UploadManagerI.h
+++ b/src/include/usercore/UploadManagerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UserCoreI.h
+++ b/src/include/usercore/UserCoreI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UserServiceI.h
+++ b/src/include/usercore/UserServiceI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UserThreadI.h
+++ b/src/include/usercore/UserThreadI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/UserThreadManagerI.h
+++ b/src/include/usercore/UserThreadManagerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/usercore/VerifyComplete.h
+++ b/src/include/usercore/VerifyComplete.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/MD5Progressive.h
+++ b/src/include/util/MD5Progressive.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilCallback.h
+++ b/src/include/util/UtilCallback.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilFs.h
+++ b/src/include/util/UtilFs.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilFsPath.h
+++ b/src/include/util/UtilFsPath.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilLinux.h
+++ b/src/include/util/UtilLinux.h
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Casey Jones <jonescaseyb@gmail.com>
+          (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilMisc.h
+++ b/src/include/util/UtilMisc.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilOs.h
+++ b/src/include/util/UtilOs.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilString.h
+++ b/src/include/util/UtilString.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilWeb.h
+++ b/src/include/util/UtilWeb.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/UtilWindows.h
+++ b/src/include/util/UtilWindows.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Casey Jones <jonescaseyb@gmail.com>
+          (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/gcBuff.h
+++ b/src/include/util/gcBuff.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/gcDDE.h
+++ b/src/include/util/gcDDE.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util/gcString.h
+++ b/src/include/util/gcString.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util_thread/BaseThread.h
+++ b/src/include/util_thread/BaseThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util_thread/ReadWriteMutex.h
+++ b/src/include/util_thread/ReadWriteMutex.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/util_thread/ThreadPool.h
+++ b/src/include/util_thread/ThreadPool.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/webcore/DLLVersion.h
+++ b/src/include/webcore/DLLVersion.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/webcore/DownloadImageInfo.h
+++ b/src/include/webcore/DownloadImageInfo.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/webcore/DumpInfo.h
+++ b/src/include/webcore/DumpInfo.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/webcore/ResumeUploadInfo.h
+++ b/src/include/webcore/ResumeUploadInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/webcore/WebCoreI.h
+++ b/src/include/webcore/WebCoreI.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcButton.h
+++ b/src/include/wx_controls/gcButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCheckBox.h
+++ b/src/include/wx_controls/gcCheckBox.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcChoice.h
+++ b/src/include/wx_controls/gcChoice.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCombo.h
+++ b/src/include/wx_controls/gcCombo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcControls.h
+++ b/src/include/wx_controls/gcControls.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomFrame.h
+++ b/src/include/wx_controls/gcCustomFrame.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomFrameButtons.h
+++ b/src/include/wx_controls/gcCustomFrameButtons.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomFrameImpl.h
+++ b/src/include/wx_controls/gcCustomFrameImpl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomFrameMove.h
+++ b/src/include/wx_controls/gcCustomFrameMove.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomFrameResize.h
+++ b/src/include/wx_controls/gcCustomFrameResize.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcCustomMenu.h
+++ b/src/include/wx_controls/gcCustomMenu.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcDialog.h
+++ b/src/include/wx_controls/gcDialog.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcFlickerFreePaint.h
+++ b/src/include/wx_controls/gcFlickerFreePaint.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcFrame.h
+++ b/src/include/wx_controls/gcFrame.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcGrid.h
+++ b/src/include/wx_controls/gcGrid.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcHyperlinkCtrl.h
+++ b/src/include/wx_controls/gcHyperlinkCtrl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcImage.h
+++ b/src/include/wx_controls/gcImage.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcImageButton.h
+++ b/src/include/wx_controls/gcImageButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcImageControl.h
+++ b/src/include/wx_controls/gcImageControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcImageHandle.h
+++ b/src/include/wx_controls/gcImageHandle.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcImgButtonCount.h
+++ b/src/include/wx_controls/gcImgButtonCount.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcManagers.h
+++ b/src/include/wx_controls/gcManagers.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcMessageBox.h
+++ b/src/include/wx_controls/gcMessageBox.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcPanel.h
+++ b/src/include/wx_controls/gcPanel.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcProgressBar.h
+++ b/src/include/wx_controls/gcProgressBar.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcRadioButton.h
+++ b/src/include/wx_controls/gcRadioButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcScrolledWindow.h
+++ b/src/include/wx_controls/gcScrolledWindow.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcSpinnerProgBar.h
+++ b/src/include/wx_controls/gcSpinnerProgBar.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcSpinningBar.h
+++ b/src/include/wx_controls/gcSpinningBar.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcStaticLine.h
+++ b/src/include/wx_controls/gcStaticLine.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcStaticText.h
+++ b/src/include/wx_controls/gcStaticText.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcTaskBar.h
+++ b/src/include/wx_controls/gcTaskBar.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcTextCtrl.h
+++ b/src/include/wx_controls/gcTextCtrl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcToggleButton.h
+++ b/src/include/wx_controls/gcToggleButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/gcUpProgBar.h
+++ b/src/include/wx_controls/gcUpProgBar.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/guiDelegate.h
+++ b/src/include/wx_controls/guiDelegate.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/include/wx_controls/wxEventDelegate.h
+++ b/src/include/wx_controls/wxEventDelegate.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/crashuploader/code/CrashuploaderMain.cpp
+++ b/src/shared/crashuploader/code/CrashuploaderMain.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/Courgette.cpp
+++ b/src/shared/mcfcore/code/Courgette.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/Courgette.h
+++ b/src/shared/mcfcore/code/Courgette.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/Log.cpp
+++ b/src/shared/mcfcore/code/Log.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/Log.h
+++ b/src/shared/mcfcore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/MCFDPReporter.cpp
+++ b/src/shared/mcfcore/code/MCFDPReporter.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/MCFDPReporter.h
+++ b/src/shared/mcfcore/code/MCFDPReporter.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/MCFMain.cpp
+++ b/src/shared/mcfcore/code/MCFMain.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/ProgressiveCRC.cpp
+++ b/src/shared/mcfcore/code/ProgressiveCRC.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/ProgressiveCRC.h
+++ b/src/shared/mcfcore/code/ProgressiveCRC.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/ProviderManager.cpp
+++ b/src/shared/mcfcore/code/ProviderManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/ProviderManager.h
+++ b/src/shared/mcfcore/code/ProviderManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/XMLSaveAndCompress.cpp
+++ b/src/shared/mcfcore/code/XMLSaveAndCompress.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/XMLSaveAndCompress.h
+++ b/src/shared/mcfcore/code/XMLSaveAndCompress.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCF.cpp
+++ b/src/shared/mcfcore/code/mcf/MCF.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCF.h
+++ b/src/shared/mcfcore/code/mcf/MCF.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCFFile.cpp
+++ b/src/shared/mcfcore/code/mcf/MCFFile.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCFFile.h
+++ b/src/shared/mcfcore/code/mcf/MCFFile.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCFHeader.cpp
+++ b/src/shared/mcfcore/code/mcf/MCFHeader.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCFHeader.h
+++ b/src/shared/mcfcore/code/mcf/MCFHeader.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCF_Http.cpp
+++ b/src/shared/mcfcore/code/mcf/MCF_Http.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCF_Patch.cpp
+++ b/src/shared/mcfcore/code/mcf/MCF_Patch.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/mcf/MCF_Save.cpp
+++ b/src/shared/mcfcore/code/mcf/MCF_Save.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/BaseMCFThread.cpp
+++ b/src/shared/mcfcore/code/thread/BaseMCFThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/BaseMCFThread.h
+++ b/src/shared/mcfcore/code/thread/BaseMCFThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/HGTController.cpp
+++ b/src/shared/mcfcore/code/thread/HGTController.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/HGTController.h
+++ b/src/shared/mcfcore/code/thread/HGTController.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/MCFServerCon.cpp
+++ b/src/shared/mcfcore/code/thread/MCFServerCon.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/MCFServerCon.h
+++ b/src/shared/mcfcore/code/thread/MCFServerCon.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SFTController.cpp
+++ b/src/shared/mcfcore/code/thread/SFTController.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SFTController.h
+++ b/src/shared/mcfcore/code/thread/SFTController.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SFTWorker.cpp
+++ b/src/shared/mcfcore/code/thread/SFTWorker.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SFTWorker.h
+++ b/src/shared/mcfcore/code/thread/SFTWorker.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SMTController.cpp
+++ b/src/shared/mcfcore/code/thread/SMTController.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SMTController.h
+++ b/src/shared/mcfcore/code/thread/SMTController.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SMTWorker.cpp
+++ b/src/shared/mcfcore/code/thread/SMTWorker.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/SMTWorker.h
+++ b/src/shared/mcfcore/code/thread/SMTWorker.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/UpdateThread.cpp
+++ b/src/shared/mcfcore/code/thread/UpdateThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/UpdateThread.h
+++ b/src/shared/mcfcore/code/thread/UpdateThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTController.cpp
+++ b/src/shared/mcfcore/code/thread/WGTController.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTController.h
+++ b/src/shared/mcfcore/code/thread/WGTController.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTControllerI.h
+++ b/src/shared/mcfcore/code/thread/WGTControllerI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTExtras.h
+++ b/src/shared/mcfcore/code/thread/WGTExtras.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTWorker.cpp
+++ b/src/shared/mcfcore/code/thread/WGTWorker.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/mcfcore/code/thread/WGTWorker.h
+++ b/src/shared/mcfcore/code/thread/WGTWorker.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/scriptcore/code/Log.cpp
+++ b/src/shared/scriptcore/code/Log.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/scriptcore/code/Log.h
+++ b/src/shared/scriptcore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/scriptcore/code/ScriptCoreMain.cpp
+++ b/src/shared/scriptcore/code/ScriptCoreMain.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/scriptcore/code/ScriptTaskThread.cpp
+++ b/src/shared/scriptcore/code/ScriptTaskThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/scriptcore/code/ScriptTaskThread.h
+++ b/src/shared/scriptcore/code/ScriptTaskThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ComplexLaunchProcess.cpp
+++ b/src/shared/servicecore/code/ComplexLaunchProcess.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ComplexLaunchProcess.h
+++ b/src/shared/servicecore/code/ComplexLaunchProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/InstallProcess.cpp
+++ b/src/shared/servicecore/code/InstallProcess.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/InstallProcess.h
+++ b/src/shared/servicecore/code/InstallProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/InstallScriptRunTime.cpp
+++ b/src/shared/servicecore/code/InstallScriptRunTime.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/InstallScriptRunTime.h
+++ b/src/shared/servicecore/code/InstallScriptRunTime.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/Log.cpp
+++ b/src/shared/servicecore/code/Log.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/Log.h
+++ b/src/shared/servicecore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/McfInit.cpp
+++ b/src/shared/servicecore/code/McfInit.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/McfInit.h
+++ b/src/shared/servicecore/code/McfInit.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ServiceCore.cpp
+++ b/src/shared/servicecore/code/ServiceCore.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ServiceCore.h
+++ b/src/shared/servicecore/code/ServiceCore.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ServiceCoreMain.cpp
+++ b/src/shared/servicecore/code/ServiceCoreMain.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ServiceMainThread.cpp
+++ b/src/shared/servicecore/code/ServiceMainThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/ServiceMainThread.h
+++ b/src/shared/servicecore/code/ServiceMainThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UnInstallBranchProcess.cpp
+++ b/src/shared/servicecore/code/UnInstallBranchProcess.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UnInstallBranchProcess.h
+++ b/src/shared/servicecore/code/UnInstallBranchProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UnInstallProcess.cpp
+++ b/src/shared/servicecore/code/UnInstallProcess.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UnInstallProcess.h
+++ b/src/shared/servicecore/code/UnInstallProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UnInstallRegKey.cpp
+++ b/src/shared/servicecore/code/UnInstallRegKey.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UpdateProcess.cpp
+++ b/src/shared/servicecore/code/UpdateProcess.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UpdateProcess.h
+++ b/src/shared/servicecore/code/UpdateProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/UpdateShortcuts.cpp
+++ b/src/shared/servicecore/code/UpdateShortcuts.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/servicecore/code/WindowsGameExplorer.cpp
+++ b/src/shared/servicecore/code/WindowsGameExplorer.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/AboutForm.cpp
+++ b/src/shared/uicore/code/AboutForm.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/AboutForm.h
+++ b/src/shared/uicore/code/AboutForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/AboutPageDev.cpp
+++ b/src/shared/uicore/code/AboutPageDev.cpp
@@ -1,13 +1,21 @@
-///////////// Copyright � 2010 Desura Pty Ltd. All rights reserved. /////////////
-//
-//   Project     : uicore
-//   File        : aboutPage_dev.cpp
-//   Description :
-//      [TODO: Write the purpose of aboutPage_dev.cpp.]
-//
-//   Created On: 9/6/2009 4:01:14 PM
-//   Created By: Mark Chandler <mailto:mark@moddb.com>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "AboutPageDev.h"

--- a/src/shared/uicore/code/AboutPageDev.h
+++ b/src/shared/uicore/code/AboutPageDev.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/AboutPageMain.cpp
+++ b/src/shared/uicore/code/AboutPageMain.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/AboutPageMain.h
+++ b/src/shared/uicore/code/AboutPageMain.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseInstallPage.cpp
+++ b/src/shared/uicore/code/BaseInstallPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseInstallPage.h
+++ b/src/shared/uicore/code/BaseInstallPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseMenuButton.cpp
+++ b/src/shared/uicore/code/BaseMenuButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseMenuButton.h
+++ b/src/shared/uicore/code/BaseMenuButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BasePage.cpp
+++ b/src/shared/uicore/code/BasePage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BasePage.h
+++ b/src/shared/uicore/code/BasePage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseTabPage.cpp
+++ b/src/shared/uicore/code/BaseTabPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseTabPage.h
+++ b/src/shared/uicore/code/BaseTabPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseToolBarControl.cpp
+++ b/src/shared/uicore/code/BaseToolBarControl.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BaseToolBarControl.h
+++ b/src/shared/uicore/code/BaseToolBarControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BreadCrumb.cpp
+++ b/src/shared/uicore/code/BreadCrumb.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/BreadCrumb.h
+++ b/src/shared/uicore/code/BreadCrumb.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ButtonStrip.cpp
+++ b/src/shared/uicore/code/ButtonStrip.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ButtonStrip.h
+++ b/src/shared/uicore/code/ButtonStrip.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKInfo.cpp
+++ b/src/shared/uicore/code/CDKInfo.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKInfo.h
+++ b/src/shared/uicore/code/CDKInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKProgress.cpp
+++ b/src/shared/uicore/code/CDKProgress.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKProgress.h
+++ b/src/shared/uicore/code/CDKProgress.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKeyForm.cpp
+++ b/src/shared/uicore/code/CDKeyForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CDKeyForm.h
+++ b/src/shared/uicore/code/CDKeyForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CefIPCPipeClient.cpp
+++ b/src/shared/uicore/code/CefIPCPipeClient.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CefIPCPipeClient.h
+++ b/src/shared/uicore/code/CefIPCPipeClient.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ChangeLogForm.cpp
+++ b/src/shared/uicore/code/ChangeLogForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ChangeLogForm.h
+++ b/src/shared/uicore/code/ChangeLogForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ChromiumMenuInfoFromMem.cpp
+++ b/src/shared/uicore/code/ChromiumMenuInfoFromMem.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ChromiumMenuInfoFromMem.h
+++ b/src/shared/uicore/code/ChromiumMenuInfoFromMem.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ComplexPrompt.cpp
+++ b/src/shared/uicore/code/ComplexPrompt.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ComplexPrompt.h
+++ b/src/shared/uicore/code/ComplexPrompt.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Console.cpp
+++ b/src/shared/uicore/code/Console.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Console.h
+++ b/src/shared/uicore/code/Console.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateForm.cpp
+++ b/src/shared/uicore/code/CreateForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateForm.h
+++ b/src/shared/uicore/code/CreateForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateInfoPage.cpp
+++ b/src/shared/uicore/code/CreateInfoPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateInfoPage.h
+++ b/src/shared/uicore/code/CreateInfoPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateOVPage.cpp
+++ b/src/shared/uicore/code/CreateOVPage.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateOVPage.h
+++ b/src/shared/uicore/code/CreateOVPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateProgPage.cpp
+++ b/src/shared/uicore/code/CreateProgPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CreateProgPage.h
+++ b/src/shared/uicore/code/CreateProgPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/CrumbInfo.h
+++ b/src/shared/uicore/code/CrumbInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DStripMenuControls.cpp
+++ b/src/shared/uicore/code/DStripMenuControls.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DStripMenuControls.h
+++ b/src/shared/uicore/code/DStripMenuControls.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DesuraControl.cpp
+++ b/src/shared/uicore/code/DesuraControl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DesuraControl.h
+++ b/src/shared/uicore/code/DesuraControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DesuraServiceError.cpp
+++ b/src/shared/uicore/code/DesuraServiceError.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DesuraServiceError.h
+++ b/src/shared/uicore/code/DesuraServiceError.h
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DispLoading.cpp
+++ b/src/shared/uicore/code/DispLoading.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/DispLoading.h
+++ b/src/shared/uicore/code/DispLoading.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/EulaForm.cpp
+++ b/src/shared/uicore/code/EulaForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/EulaForm.h
+++ b/src/shared/uicore/code/EulaForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ExeSelectForm.cpp
+++ b/src/shared/uicore/code/ExeSelectForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ExeSelectForm.h
+++ b/src/shared/uicore/code/ExeSelectForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/FrameButtons.cpp
+++ b/src/shared/uicore/code/FrameButtons.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/FrameButtons.h
+++ b/src/shared/uicore/code/FrameButtons.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/GameDiscForm.cpp
+++ b/src/shared/uicore/code/GameDiscForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/GameDiscForm.h
+++ b/src/shared/uicore/code/GameDiscForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HeaderButton.cpp
+++ b/src/shared/uicore/code/HeaderButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HeaderButton.h
+++ b/src/shared/uicore/code/HeaderButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HtmlTabPage.cpp
+++ b/src/shared/uicore/code/HtmlTabPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HtmlTabPage.h
+++ b/src/shared/uicore/code/HtmlTabPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HtmlToolBarControl.cpp
+++ b/src/shared/uicore/code/HtmlToolBarControl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/HtmlToolBarControl.h
+++ b/src/shared/uicore/code/HtmlToolBarControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ICheckFinishPage.cpp
+++ b/src/shared/uicore/code/ICheckFinishPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ICheckFinishPage.h
+++ b/src/shared/uicore/code/ICheckFinishPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ICheckProgressPage.cpp
+++ b/src/shared/uicore/code/ICheckProgressPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ICheckProgressPage.h
+++ b/src/shared/uicore/code/ICheckProgressPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallBannerPage.cpp
+++ b/src/shared/uicore/code/InstallBannerPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallBannerPage.h
+++ b/src/shared/uicore/code/InstallBannerPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallBranch.cpp
+++ b/src/shared/uicore/code/InstallBranch.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallBranch.h
+++ b/src/shared/uicore/code/InstallBranch.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDLPage.cpp
+++ b/src/shared/uicore/code/InstallDLPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDLPage.h
+++ b/src/shared/uicore/code/InstallDLPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDLToolPage.cpp
+++ b/src/shared/uicore/code/InstallDLToolPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDLToolPage.h
+++ b/src/shared/uicore/code/InstallDLToolPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDVPage.cpp
+++ b/src/shared/uicore/code/InstallDVPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallDVPage.h
+++ b/src/shared/uicore/code/InstallDVPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallGIPage.cpp
+++ b/src/shared/uicore/code/InstallGIPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallGIPage.h
+++ b/src/shared/uicore/code/InstallGIPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINCPage.cpp
+++ b/src/shared/uicore/code/InstallINCPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINCPage.h
+++ b/src/shared/uicore/code/InstallINCPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINPage.cpp
+++ b/src/shared/uicore/code/InstallINPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINPage.h
+++ b/src/shared/uicore/code/InstallINPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINToolPage.cpp
+++ b/src/shared/uicore/code/InstallINToolPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallINToolPage.h
+++ b/src/shared/uicore/code/InstallINToolPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallPrompt.cpp
+++ b/src/shared/uicore/code/InstallPrompt.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallPrompt.h
+++ b/src/shared/uicore/code/InstallPrompt.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallVIPage.cpp
+++ b/src/shared/uicore/code/InstallVIPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallVIPage.h
+++ b/src/shared/uicore/code/InstallVIPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallVInfoPage.cpp
+++ b/src/shared/uicore/code/InstallVInfoPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallVInfoPage.h
+++ b/src/shared/uicore/code/InstallVInfoPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallWaitPage.cpp
+++ b/src/shared/uicore/code/InstallWaitPage.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InstallWaitPage.h
+++ b/src/shared/uicore/code/InstallWaitPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InternalLink.cpp
+++ b/src/shared/uicore/code/InternalLink.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/InternalLink.h
+++ b/src/shared/uicore/code/InternalLink.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemForm.cpp
+++ b/src/shared/uicore/code/ItemForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemForm.h
+++ b/src/shared/uicore/code/ItemForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemTabPage.cpp
+++ b/src/shared/uicore/code/ItemTabPage.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemTabPage.h
+++ b/src/shared/uicore/code/ItemTabPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemToolBarControl.cpp
+++ b/src/shared/uicore/code/ItemToolBarControl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemToolBarControl.h
+++ b/src/shared/uicore/code/ItemToolBarControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemUpdateForm.cpp
+++ b/src/shared/uicore/code/ItemUpdateForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ItemUpdateForm.h
+++ b/src/shared/uicore/code/ItemUpdateForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/LaunchPrompt.cpp
+++ b/src/shared/uicore/code/LaunchPrompt.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/LaunchPrompt.h
+++ b/src/shared/uicore/code/LaunchPrompt.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Log.cpp
+++ b/src/shared/uicore/code/Log.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Log.h
+++ b/src/shared/uicore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/LoginForm.cpp
+++ b/src/shared/uicore/code/LoginForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/LoginForm.h
+++ b/src/shared/uicore/code/LoginForm.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainApp.cpp
+++ b/src/shared/uicore/code/MainApp.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainApp.h
+++ b/src/shared/uicore/code/MainApp.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainApp_cvar.cpp
+++ b/src/shared/uicore/code/MainApp_cvar.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainApp_internal.cpp
+++ b/src/shared/uicore/code/MainApp_internal.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainApp_wildcards.cpp
+++ b/src/shared/uicore/code/MainApp_wildcards.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainForm.cpp
+++ b/src/shared/uicore/code/MainForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainForm.h
+++ b/src/shared/uicore/code/MainForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainFormCustomFrame.cpp
+++ b/src/shared/uicore/code/MainFormCustomFrame.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainFormCustomFrame.h
+++ b/src/shared/uicore/code/MainFormCustomFrame.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainFormLeftBorder.cpp
+++ b/src/shared/uicore/code/MainFormLeftBorder.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainFormLeftBorder.h
+++ b/src/shared/uicore/code/MainFormLeftBorder.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainMenuButton.cpp
+++ b/src/shared/uicore/code/MainMenuButton.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MainMenuButton.h
+++ b/src/shared/uicore/code/MainMenuButton.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Managers.cpp
+++ b/src/shared/uicore/code/Managers.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/Managers.h
+++ b/src/shared/uicore/code/Managers.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuFiller.cpp
+++ b/src/shared/uicore/code/MenuFiller.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuFiller.h
+++ b/src/shared/uicore/code/MenuFiller.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuSeperator.cpp
+++ b/src/shared/uicore/code/MenuSeperator.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuSeperator.h
+++ b/src/shared/uicore/code/MenuSeperator.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuStrip.cpp
+++ b/src/shared/uicore/code/MenuStrip.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/MenuStrip.h
+++ b/src/shared/uicore/code/MenuStrip.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizard.cpp
+++ b/src/shared/uicore/code/ModWizard.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizard.h
+++ b/src/shared/uicore/code/ModWizard.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizardFinPage.cpp
+++ b/src/shared/uicore/code/ModWizardFinPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizardFinPage.h
+++ b/src/shared/uicore/code/ModWizardFinPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizardInfoPage.cpp
+++ b/src/shared/uicore/code/ModWizardInfoPage.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 Desura Pty Ltd. All rights reserved.  /////////////
-//
-//   Project     : uicore
-//   File        : mwInfoPage.cpp
-//   Description :
-//      [Write the purpose of mwInfoPage.cpp.]
-//
-//   Created On: 12/19/2008 9:29:43 AM
-//   Created By: Mark Chandler <mailto:mark@moddb.com>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "ModWizardInfoPage.h"

--- a/src/shared/uicore/code/ModWizardInfoPage.h
+++ b/src/shared/uicore/code/ModWizardInfoPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizardProgPage.cpp
+++ b/src/shared/uicore/code/ModWizardProgPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/ModWizardProgPage.h
+++ b/src/shared/uicore/code/ModWizardProgPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/NewAccountDialog.cpp
+++ b/src/shared/uicore/code/NewAccountDialog.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/NewAccountDialog.h
+++ b/src/shared/uicore/code/NewAccountDialog.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/NewsForm.cpp
+++ b/src/shared/uicore/code/NewsForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/NewsForm.h
+++ b/src/shared/uicore/code/NewsForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/PasswordReminder.cpp
+++ b/src/shared/uicore/code/PasswordReminder.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/PasswordReminder.h
+++ b/src/shared/uicore/code/PasswordReminder.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/PreloadPage.cpp
+++ b/src/shared/uicore/code/PreloadPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/PreloadPage.h
+++ b/src/shared/uicore/code/PreloadPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/SearchControl.cpp
+++ b/src/shared/uicore/code/SearchControl.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/SearchControl.h
+++ b/src/shared/uicore/code/SearchControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/SteamUser.cpp
+++ b/src/shared/uicore/code/SteamUser.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/SteamUser.h
+++ b/src/shared/uicore/code/SteamUser.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/StripMenuButton.cpp
+++ b/src/shared/uicore/code/StripMenuButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/StripMenuButton.h
+++ b/src/shared/uicore/code/StripMenuButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_BaseMenu.cpp
+++ b/src/shared/uicore/code/TBI_BaseMenu.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_BaseMenu.h
+++ b/src/shared/uicore/code/TBI_BaseMenu.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_GameMenu.cpp
+++ b/src/shared/uicore/code/TBI_GameMenu.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_GameMenu.h
+++ b/src/shared/uicore/code/TBI_GameMenu.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_ModMenu.cpp
+++ b/src/shared/uicore/code/TBI_ModMenu.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_ModMenu.h
+++ b/src/shared/uicore/code/TBI_ModMenu.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_UpdateMenu.cpp
+++ b/src/shared/uicore/code/TBI_UpdateMenu.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_UpdateMenu.h
+++ b/src/shared/uicore/code/TBI_UpdateMenu.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_WindowMenu.cpp
+++ b/src/shared/uicore/code/TBI_WindowMenu.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TBI_WindowMenu.h
+++ b/src/shared/uicore/code/TBI_WindowMenu.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabButton.cpp
+++ b/src/shared/uicore/code/TabButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabButton.h
+++ b/src/shared/uicore/code/TabButton.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabControl.cpp
+++ b/src/shared/uicore/code/TabControl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabControl.h
+++ b/src/shared/uicore/code/TabControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabHandler.cpp
+++ b/src/shared/uicore/code/TabHandler.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabHandler.h
+++ b/src/shared/uicore/code/TabHandler.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TabPanel.h
+++ b/src/shared/uicore/code/TabPanel.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TaskBarIcon.cpp
+++ b/src/shared/uicore/code/TaskBarIcon.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TaskBarIcon.h
+++ b/src/shared/uicore/code/TaskBarIcon.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TaskBarIcon_Ballon.cpp
+++ b/src/shared/uicore/code/TaskBarIcon_Ballon.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/TaskBarIcon_Icon.cpp
+++ b/src/shared/uicore/code/TaskBarIcon_Icon.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UICoreEntry.cpp
+++ b/src/shared/uicore/code/UICoreEntry.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UICoreMain.cpp
+++ b/src/shared/uicore/code/UICoreMain.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallForm.cpp
+++ b/src/shared/uicore/code/UninstallForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallForm.h
+++ b/src/shared/uicore/code/UninstallForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallInfoPage.cpp
+++ b/src/shared/uicore/code/UninstallInfoPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallInfoPage.h
+++ b/src/shared/uicore/code/UninstallInfoPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallProgressPage.cpp
+++ b/src/shared/uicore/code/UninstallProgressPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UninstallProgressPage.h
+++ b/src/shared/uicore/code/UninstallProgressPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadForm.cpp
+++ b/src/shared/uicore/code/UploadForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadForm.h
+++ b/src/shared/uicore/code/UploadForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadInfoPage.cpp
+++ b/src/shared/uicore/code/UploadInfoPage.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadInfoPage.h
+++ b/src/shared/uicore/code/UploadInfoPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadProgPage.cpp
+++ b/src/shared/uicore/code/UploadProgPage.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadProgPage.h
+++ b/src/shared/uicore/code/UploadProgPage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadPrompt.cpp
+++ b/src/shared/uicore/code/UploadPrompt.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UploadPrompt.h
+++ b/src/shared/uicore/code/UploadPrompt.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UsernameBox.cpp
+++ b/src/shared/uicore/code/UsernameBox.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/UsernameBox.h
+++ b/src/shared/uicore/code/UsernameBox.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcImgLoader.cpp
+++ b/src/shared/uicore/code/gcImgLoader.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcImgLoader.h
+++ b/src/shared/uicore/code/gcImgLoader.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSBinding.cpp
+++ b/src/shared/uicore/code/gcJSBinding.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSBinding.h
+++ b/src/shared/uicore/code/gcJSBinding.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSBranchInfo.cpp
+++ b/src/shared/uicore/code/gcJSBranchInfo.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSBranchInfo.h
+++ b/src/shared/uicore/code/gcJSBranchInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSEvents.cpp
+++ b/src/shared/uicore/code/gcJSEvents.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSEvents.h
+++ b/src/shared/uicore/code/gcJSEvents.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSItemInfo.cpp
+++ b/src/shared/uicore/code/gcJSItemInfo.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSItemInfo.h
+++ b/src/shared/uicore/code/gcJSItemInfo.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSLinks.cpp
+++ b/src/shared/uicore/code/gcJSLinks.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSLinks.h
+++ b/src/shared/uicore/code/gcJSLinks.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSSettings.cpp
+++ b/src/shared/uicore/code/gcJSSettings.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSSettings.h
+++ b/src/shared/uicore/code/gcJSSettings.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSUploads.cpp
+++ b/src/shared/uicore/code/gcJSUploads.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSUploads.h
+++ b/src/shared/uicore/code/gcJSUploads.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSUserInfo.cpp
+++ b/src/shared/uicore/code/gcJSUserInfo.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcJSUserInfo.h
+++ b/src/shared/uicore/code/gcJSUserInfo.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcMiscWebControl.cpp
+++ b/src/shared/uicore/code/gcMiscWebControl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcMiscWebControl.h
+++ b/src/shared/uicore/code/gcMiscWebControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcSchemeBase.cpp
+++ b/src/shared/uicore/code/gcSchemeBase.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcSchemeBase.h
+++ b/src/shared/uicore/code/gcSchemeBase.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcThemeLoader.cpp
+++ b/src/shared/uicore/code/gcThemeLoader.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcThemeLoader.h
+++ b/src/shared/uicore/code/gcThemeLoader.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcUpdateForm.cpp
+++ b/src/shared/uicore/code/gcUpdateForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcUpdateForm.h
+++ b/src/shared/uicore/code/gcUpdateForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWCEvents.cpp
+++ b/src/shared/uicore/code/gcWCEvents.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWCEvents.h
+++ b/src/shared/uicore/code/gcWCEvents.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWCEvents_js.cpp
+++ b/src/shared/uicore/code/gcWCEvents_js.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWCEvents_win.cpp
+++ b/src/shared/uicore/code/gcWCEvents_win.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWCUtil.cpp
+++ b/src/shared/uicore/code/gcWCUtil.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebControl.cpp
+++ b/src/shared/uicore/code/gcWebControl.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebControl.h
+++ b/src/shared/uicore/code/gcWebControl.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebControlI.h
+++ b/src/shared/uicore/code/gcWebControlI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebFakeBrowser.cpp
+++ b/src/shared/uicore/code/gcWebFakeBrowser.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebFakeBrowser.h
+++ b/src/shared/uicore/code/gcWebFakeBrowser.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebHost.cpp
+++ b/src/shared/uicore/code/gcWebHost.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/uicore/code/gcWebHost.h
+++ b/src/shared/uicore/code/gcWebHost.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BDManager.cpp
+++ b/src/shared/usercore/code/BDManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BDManager.h
+++ b/src/shared/usercore/code/BDManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BaseItemServiceTask.cpp
+++ b/src/shared/usercore/code/BaseItemServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BaseItemServiceTask.h
+++ b/src/shared/usercore/code/BaseItemServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BaseItemTask.cpp
+++ b/src/shared/usercore/code/BaseItemTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BaseItemTask.h
+++ b/src/shared/usercore/code/BaseItemTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BaseUserThread.h
+++ b/src/shared/usercore/code/BaseUserThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BranchInfo.cpp
+++ b/src/shared/usercore/code/BranchInfo.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BranchInfo.h
+++ b/src/shared/usercore/code/BranchInfo.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BranchInstallInfo.cpp
+++ b/src/shared/usercore/code/BranchInstallInfo.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/BranchInstallInfo.h
+++ b/src/shared/usercore/code/BranchInstallInfo.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CDKeyManager.cpp
+++ b/src/shared/usercore/code/CDKeyManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CDKeyManager.h
+++ b/src/shared/usercore/code/CDKeyManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CIPManager.cpp
+++ b/src/shared/usercore/code/CIPManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CIPManager.h
+++ b/src/shared/usercore/code/CIPManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ComplexLaunchServiceTask.cpp
+++ b/src/shared/usercore/code/ComplexLaunchServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ComplexLaunchServiceTask.h
+++ b/src/shared/usercore/code/ComplexLaunchServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CreateMCFThread.cpp
+++ b/src/shared/usercore/code/CreateMCFThread.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/CreateMCFThread.h
+++ b/src/shared/usercore/code/CreateMCFThread.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadTask.cpp
+++ b/src/shared/usercore/code/DownloadTask.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadTask.h
+++ b/src/shared/usercore/code/DownloadTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadToolItemTask.cpp
+++ b/src/shared/usercore/code/DownloadToolItemTask.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadToolItemTask.h
+++ b/src/shared/usercore/code/DownloadToolItemTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadToolTask.cpp
+++ b/src/shared/usercore/code/DownloadToolTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadToolTask.h
+++ b/src/shared/usercore/code/DownloadToolTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadUpdateTask.cpp
+++ b/src/shared/usercore/code/DownloadUpdateTask.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/DownloadUpdateTask.h
+++ b/src/shared/usercore/code/DownloadUpdateTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GameExplorerInfo_win.cpp
+++ b/src/shared/usercore/code/GameExplorerInfo_win.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GameExplorerManager.h
+++ b/src/shared/usercore/code/GameExplorerManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GameExplorerManager_win.cpp
+++ b/src/shared/usercore/code/GameExplorerManager_win.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GatherInfoTask.cpp
+++ b/src/shared/usercore/code/GatherInfoTask.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GatherInfoTask.h
+++ b/src/shared/usercore/code/GatherInfoTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GatherInfoThread.cpp
+++ b/src/shared/usercore/code/GatherInfoThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GatherInfoThread.h
+++ b/src/shared/usercore/code/GatherInfoThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GetItemListThread.cpp
+++ b/src/shared/usercore/code/GetItemListThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/GetItemListThread.h
+++ b/src/shared/usercore/code/GetItemListThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallCheckTask.cpp
+++ b/src/shared/usercore/code/InstallCheckTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallCheckTask.h
+++ b/src/shared/usercore/code/InstallCheckTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallHandler.cpp
+++ b/src/shared/usercore/code/InstallHandler.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallHandler.h
+++ b/src/shared/usercore/code/InstallHandler.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallInfo.cpp
+++ b/src/shared/usercore/code/InstallInfo.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallInfo.h
+++ b/src/shared/usercore/code/InstallInfo.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallServiceTask.cpp
+++ b/src/shared/usercore/code/InstallServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallServiceTask.h
+++ b/src/shared/usercore/code/InstallServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallToolTask.cpp
+++ b/src/shared/usercore/code/InstallToolTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstallToolTask.h
+++ b/src/shared/usercore/code/InstallToolTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstalledWizardThread.cpp
+++ b/src/shared/usercore/code/InstalledWizardThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/InstalledWizardThread.h
+++ b/src/shared/usercore/code/InstalledWizardThread.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandle.cpp
+++ b/src/shared/usercore/code/ItemHandle.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandle.h
+++ b/src/shared/usercore/code/ItemHandle.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandleEvents.cpp
+++ b/src/shared/usercore/code/ItemHandleEvents.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandleEvents.h
+++ b/src/shared/usercore/code/ItemHandleEvents.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandle_nix.cpp
+++ b/src/shared/usercore/code/ItemHandle_nix.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
+          (C) r-ick <github.com/r-ick>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemHandle_win.cpp
+++ b/src/shared/usercore/code/ItemHandle_win.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemInfo.cpp
+++ b/src/shared/usercore/code/ItemInfo.cpp
@@ -1,6 +1,11 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) r-ick <github.com/r-ick>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemInfo.h
+++ b/src/shared/usercore/code/ItemInfo.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemManager.cpp
+++ b/src/shared/usercore/code/ItemManager.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) r-ick <github.com/r-ick>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemManager.h
+++ b/src/shared/usercore/code/ItemManager.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemTaskGroup.cpp
+++ b/src/shared/usercore/code/ItemTaskGroup.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemTaskGroup.h
+++ b/src/shared/usercore/code/ItemTaskGroup.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemThread.cpp
+++ b/src/shared/usercore/code/ItemThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ItemThread.h
+++ b/src/shared/usercore/code/ItemThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/LaunchTask.h
+++ b/src/shared/usercore/code/LaunchTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/Log.cpp
+++ b/src/shared/usercore/code/Log.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/Log.h
+++ b/src/shared/usercore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/MCFThread.h
+++ b/src/shared/usercore/code/MCFThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/McfManager.cpp
+++ b/src/shared/usercore/code/McfManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/McfManager.h
+++ b/src/shared/usercore/code/McfManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolIPCPipeClient.cpp
+++ b/src/shared/usercore/code/ToolIPCPipeClient.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolIPCPipeClient.h
+++ b/src/shared/usercore/code/ToolIPCPipeClient.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInfo.cpp
+++ b/src/shared/usercore/code/ToolInfo.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInfo.h
+++ b/src/shared/usercore/code/ToolInfo.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInstallThread.cpp
+++ b/src/shared/usercore/code/ToolInstallThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInstallThread.h
+++ b/src/shared/usercore/code/ToolInstallThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInstallThread_nix.cpp
+++ b/src/shared/usercore/code/ToolInstallThread_nix.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolInstallThread_win.cpp
+++ b/src/shared/usercore/code/ToolInstallThread_win.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolManager.cpp
+++ b/src/shared/usercore/code/ToolManager.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolManager.h
+++ b/src/shared/usercore/code/ToolManager.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolManager_Script.cpp
+++ b/src/shared/usercore/code/ToolManager_Script.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolManager_lin.cpp
+++ b/src/shared/usercore/code/ToolManager_lin.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolManager_win.cpp
+++ b/src/shared/usercore/code/ToolManager_win.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolTransaction.cpp
+++ b/src/shared/usercore/code/ToolTransaction.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ToolTransaction.h
+++ b/src/shared/usercore/code/ToolTransaction.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIBaseServiceTask.cpp
+++ b/src/shared/usercore/code/UIBaseServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIBaseServiceTask.h
+++ b/src/shared/usercore/code/UIBaseServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIBranchServiceTask.cpp
+++ b/src/shared/usercore/code/UIBranchServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIBranchServiceTask.h
+++ b/src/shared/usercore/code/UIBranchServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIComplexModServiceTask.cpp
+++ b/src/shared/usercore/code/UIComplexModServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIComplexModServiceTask.h
+++ b/src/shared/usercore/code/UIComplexModServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIPatchServiceTask.cpp
+++ b/src/shared/usercore/code/UIPatchServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIPatchServiceTask.h
+++ b/src/shared/usercore/code/UIPatchServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIServiceTask.cpp
+++ b/src/shared/usercore/code/UIServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIServiceTask.h
+++ b/src/shared/usercore/code/UIServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIUpdateServiceTask.cpp
+++ b/src/shared/usercore/code/UIUpdateServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UIUpdateServiceTask.h
+++ b/src/shared/usercore/code/UIUpdateServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UpdateThread.cpp
+++ b/src/shared/usercore/code/UpdateThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UpdateThread.h
+++ b/src/shared/usercore/code/UpdateThread.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UpdateThread_Old.cpp
+++ b/src/shared/usercore/code/UpdateThread_Old.cpp
@@ -1,6 +1,11 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UpdateThread_Old.h
+++ b/src/shared/usercore/code/UpdateThread_Old.h
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadInfoThread.cpp
+++ b/src/shared/usercore/code/UploadInfoThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadInfoThread.h
+++ b/src/shared/usercore/code/UploadInfoThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadManager.cpp
+++ b/src/shared/usercore/code/UploadManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadManager.h
+++ b/src/shared/usercore/code/UploadManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadPrepThread.cpp
+++ b/src/shared/usercore/code/UploadPrepThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadPrepThread.h
+++ b/src/shared/usercore/code/UploadPrepThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadResumeThread.cpp
+++ b/src/shared/usercore/code/UploadResumeThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadResumeThread.h
+++ b/src/shared/usercore/code/UploadResumeThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadThread.cpp
+++ b/src/shared/usercore/code/UploadThread.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UploadThread.h
+++ b/src/shared/usercore/code/UploadThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/User.cpp
+++ b/src/shared/usercore/code/User.cpp
@@ -1,6 +1,10 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/User.h
+++ b/src/shared/usercore/code/User.h
@@ -1,13 +1,21 @@
-////////////// Copyright © 2010 Desura Pty Ltd. All rights reserved.  /////////////
-//
-//   Project     : UserCore::Usercore
-//   File        : UserCore::User.h
-//   Description :
-//      [Write the purpose of UserCore::User.h.]
-//
-//   Created On: 9/23/2008 5:00:03 PM
-//   Created By: Mark Chandler <mailto:mark@moddb.com>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #ifndef DESURA_USER_H
 #define DESURA_USER_H

--- a/src/shared/usercore/code/UserCoreMain.cpp
+++ b/src/shared/usercore/code/UserCoreMain.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserIPCPipeClient.cpp
+++ b/src/shared/usercore/code/UserIPCPipeClient.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserIPCPipeClient.h
+++ b/src/shared/usercore/code/UserIPCPipeClient.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserTask.cpp
+++ b/src/shared/usercore/code/UserTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserTask.h
+++ b/src/shared/usercore/code/UserTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserTasks.cpp
+++ b/src/shared/usercore/code/UserTasks.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserTasks.h
+++ b/src/shared/usercore/code/UserTasks.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserThreadManager.cpp
+++ b/src/shared/usercore/code/UserThreadManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/UserThreadManager.h
+++ b/src/shared/usercore/code/UserThreadManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/User_Login.cpp
+++ b/src/shared/usercore/code/User_Login.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/User_nix.cpp
+++ b/src/shared/usercore/code/User_nix.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/User_win.cpp
+++ b/src/shared/usercore/code/User_win.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSBaseTask.cpp
+++ b/src/shared/usercore/code/VSBaseTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSBaseTask.h
+++ b/src/shared/usercore/code/VSBaseTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckInstall.cpp
+++ b/src/shared/usercore/code/VSCheckInstall.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckInstall.h
+++ b/src/shared/usercore/code/VSCheckInstall.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckMcf.cpp
+++ b/src/shared/usercore/code/VSCheckMcf.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckMcf.h
+++ b/src/shared/usercore/code/VSCheckMcf.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckMcfDownload.cpp
+++ b/src/shared/usercore/code/VSCheckMcfDownload.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSCheckMcfDownload.h
+++ b/src/shared/usercore/code/VSCheckMcfDownload.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSDownloadMissing.cpp
+++ b/src/shared/usercore/code/VSDownloadMissing.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSDownloadMissing.h
+++ b/src/shared/usercore/code/VSDownloadMissing.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSInstallMissing.cpp
+++ b/src/shared/usercore/code/VSInstallMissing.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VSInstallMissing.h
+++ b/src/shared/usercore/code/VSInstallMissing.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ValidateTask.cpp
+++ b/src/shared/usercore/code/ValidateTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/ValidateTask.h
+++ b/src/shared/usercore/code/ValidateTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VerifyServiceTask.cpp
+++ b/src/shared/usercore/code/VerifyServiceTask.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/usercore/code/VerifyServiceTask.h
+++ b/src/shared/usercore/code/VerifyServiceTask.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/BZip2.cpp
+++ b/src/shared/utilcore/code/BZip2.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/Browser.cpp
+++ b/src/shared/utilcore/code/Browser.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/Browser.h
+++ b/src/shared/utilcore/code/Browser.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/BrowserTest.cpp
+++ b/src/shared/utilcore/code/BrowserTest.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/BrowserTest.h
+++ b/src/shared/utilcore/code/BrowserTest.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CDOverView.cpp
+++ b/src/shared/utilcore/code/CDOverView.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CDOverView.h
+++ b/src/shared/utilcore/code/CDOverView.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CDProcess.cpp
+++ b/src/shared/utilcore/code/CDProcess.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CDProcess.h
+++ b/src/shared/utilcore/code/CDProcess.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ChangeDirForm.cpp
+++ b/src/shared/utilcore/code/ChangeDirForm.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ChangeDirForm.h
+++ b/src/shared/utilcore/code/ChangeDirForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ChangeDirThread.cpp
+++ b/src/shared/utilcore/code/ChangeDirThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ChangeDirThread.h
+++ b/src/shared/utilcore/code/ChangeDirThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ControlerForm.cpp
+++ b/src/shared/utilcore/code/ControlerForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ControlerForm.h
+++ b/src/shared/utilcore/code/ControlerForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpForm.cpp
+++ b/src/shared/utilcore/code/CrashDumpForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpForm.h
+++ b/src/shared/utilcore/code/CrashDumpForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpThread.cpp
+++ b/src/shared/utilcore/code/CrashDumpThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpThread.h
+++ b/src/shared/utilcore/code/CrashDumpThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpUploadThread.cpp
+++ b/src/shared/utilcore/code/CrashDumpUploadThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/CrashDumpUploadThread.h
+++ b/src/shared/utilcore/code/CrashDumpUploadThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/FlashDebug.cpp
+++ b/src/shared/utilcore/code/FlashDebug.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/FlashDebug.h
+++ b/src/shared/utilcore/code/FlashDebug.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/Log.cpp
+++ b/src/shared/utilcore/code/Log.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/Log.h
+++ b/src/shared/utilcore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/McfViewerForm.cpp
+++ b/src/shared/utilcore/code/McfViewerForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/McfViewerForm.h
+++ b/src/shared/utilcore/code/McfViewerForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/MiniDumpGenerator_Extern.cpp
+++ b/src/shared/utilcore/code/MiniDumpGenerator_Extern.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/MiniDumpGenerator_Extern.h
+++ b/src/shared/utilcore/code/MiniDumpGenerator_Extern.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ToolInstallForm.cpp
+++ b/src/shared/utilcore/code/ToolInstallForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ToolInstallForm.h
+++ b/src/shared/utilcore/code/ToolInstallForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ToolInstallThread.cpp
+++ b/src/shared/utilcore/code/ToolInstallThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/ToolInstallThread.h
+++ b/src/shared/utilcore/code/ToolInstallThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UDFProgressPanel.cpp
+++ b/src/shared/utilcore/code/UDFProgressPanel.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UDFProgressPanel.h
+++ b/src/shared/utilcore/code/UDFProgressPanel.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UDFSettingsPanel.cpp
+++ b/src/shared/utilcore/code/UDFSettingsPanel.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UDFSettingsPanel.h
+++ b/src/shared/utilcore/code/UDFSettingsPanel.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UninstallAllThread.cpp
+++ b/src/shared/utilcore/code/UninstallAllThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UninstallAllThread.h
+++ b/src/shared/utilcore/code/UninstallAllThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UninstallDesuraForm.cpp
+++ b/src/shared/utilcore/code/UninstallDesuraForm.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UninstallDesuraForm.h
+++ b/src/shared/utilcore/code/UninstallDesuraForm.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UtilCoreEntry.cpp
+++ b/src/shared/utilcore/code/UtilCoreEntry.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/utilcore/code/UtilCoreMain.cpp
+++ b/src/shared/utilcore/code/UtilCoreMain.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/ImageCache.cpp
+++ b/src/shared/webcore/code/ImageCache.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/ImageCache.h
+++ b/src/shared/webcore/code/ImageCache.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/Log.cpp
+++ b/src/shared/webcore/code/Log.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/Log.h
+++ b/src/shared/webcore/code/Log.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/WebCore.cpp
+++ b/src/shared/webcore/code/WebCore.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/WebCore.h
+++ b/src/shared/webcore/code/WebCore.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/WebCoreMain.cpp
+++ b/src/shared/webcore/code/WebCoreMain.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/WebCore_External.cpp
+++ b/src/shared/webcore/code/WebCore_External.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/shared/webcore/code/WebCore_Internal.cpp
+++ b/src/shared/webcore/code/WebCore_Internal.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCClass.cpp
+++ b/src/static/ipc_pipe/code/IPCClass.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCClass.h
+++ b/src/static/ipc_pipe/code/IPCClass.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCLockable.h
+++ b/src/static/ipc_pipe/code/IPCLockable.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCManager.cpp
+++ b/src/static/ipc_pipe/code/IPCManager.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCManager.h
+++ b/src/static/ipc_pipe/code/IPCManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCMessage.h
+++ b/src/static/ipc_pipe/code/IPCMessage.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCParameter.cpp
+++ b/src/static/ipc_pipe/code/IPCParameter.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCParameter.h
+++ b/src/static/ipc_pipe/code/IPCParameter.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCParameterI.h
+++ b/src/static/ipc_pipe/code/IPCParameterI.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeAuth.h
+++ b/src/static/ipc_pipe/code/IPCPipeAuth.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeBase.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeBase.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeBase.h
+++ b/src/static/ipc_pipe/code/IPCPipeBase.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeBase_Nix.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeBase_Nix.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeClient.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeClient.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeClient.h
+++ b/src/static/ipc_pipe/code/IPCPipeClient.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeClient_Nix.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeClient_Nix.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeHelper.h
+++ b/src/static/ipc_pipe/code/IPCPipeHelper.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeServer.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeServer.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeServer.h
+++ b/src/static/ipc_pipe/code/IPCPipeServer.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/ipc_pipe/code/IPCPipeServer_Nix.cpp
+++ b/src/static/ipc_pipe/code/IPCPipeServer_Nix.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/CVar.cpp
+++ b/src/static/managers/code/CVar.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/CVarManager.cpp
+++ b/src/static/managers/code/CVarManager.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/CVarManager.h
+++ b/src/static/managers/code/CVarManager.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/ConCommand.cpp
+++ b/src/static/managers/code/ConCommand.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/ConCommandManager.cpp
+++ b/src/static/managers/code/ConCommandManager.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/ConCommandManager.h
+++ b/src/static/managers/code/ConCommandManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/LanguageManager.cpp
+++ b/src/static/managers/code/LanguageManager.cpp
@@ -1,6 +1,11 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/LanguageManager.h
+++ b/src/static/managers/code/LanguageManager.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/Managers.cpp
+++ b/src/static/managers/code/Managers.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/Theme.cpp
+++ b/src/static/managers/code/Theme.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/Theme.h
+++ b/src/static/managers/code/Theme.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/ThemeManager.cpp
+++ b/src/static/managers/code/ThemeManager.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/ThemeManager.h
+++ b/src/static/managers/code/ThemeManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/WildcardManager.cpp
+++ b/src/static/managers/code/WildcardManager.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/WindowManager.cpp
+++ b/src/static/managers/code/WindowManager.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/managers/code/WindowManager.h
+++ b/src/static/managers/code/WindowManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/mdump/code/MiniDumpGenerator_lin.cpp
+++ b/src/static/mdump/code/MiniDumpGenerator_lin.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/mdump/code/MiniDumpGenerator_win.cpp
+++ b/src/static/mdump/code/MiniDumpGenerator_win.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/ScriptCore.cpp
+++ b/src/static/scriptengine/code/ScriptCore.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/ScriptCore.h
+++ b/src/static/scriptengine/code/ScriptCore.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/ScriptCoreHelper.cpp
+++ b/src/static/scriptengine/code/ScriptCoreHelper.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/ScriptCoreInternal.cpp
+++ b/src/static/scriptengine/code/ScriptCoreInternal.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/ScriptCoreInternal.h
+++ b/src/static/scriptengine/code/ScriptCoreInternal.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsExtensions.cpp
+++ b/src/static/scriptengine/code/jsExtensions.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsFS.cpp
+++ b/src/static/scriptengine/code/jsFS.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsFS.h
+++ b/src/static/scriptengine/code/jsFS.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsItem.cpp
+++ b/src/static/scriptengine/code/jsItem.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsItem.h
+++ b/src/static/scriptengine/code/jsItem.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsWin.cpp
+++ b/src/static/scriptengine/code/jsWin.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/scriptengine/code/jsWin.h
+++ b/src/static/scriptengine/code/jsWin.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/umcf/code/UMcf.cpp
+++ b/src/static/umcf/code/UMcf.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/umcf/code/UMcfFile.cpp
+++ b/src/static/umcf/code/UMcfFile.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/umcf/code/UMcfFile_utils.cpp
+++ b/src/static/umcf/code/UMcfFile_utils.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/umcf/code/UMcfFile_utils.h
+++ b/src/static/umcf/code/UMcfFile_utils.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/umcf/code/UMcfHeader.cpp
+++ b/src/static/umcf/code/UMcfHeader.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/MD5Progressive.cpp
+++ b/src/static/util/code/MD5Progressive.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/MD5Wrapper.cpp
+++ b/src/static/util/code/MD5Wrapper.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/MD5Wrapper.h
+++ b/src/static/util/code/MD5Wrapper.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilBZip2.cpp
+++ b/src/static/util/code/UtilBZip2.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilFsPath.cpp
+++ b/src/static/util/code/UtilFsPath.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilLinux.cpp
+++ b/src/static/util/code/UtilLinux.cpp
@@ -1,6 +1,12 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Casey Jones <jonescaseyb@gmail.com>
+          (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Mark Chandler <mark@moddb.com>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilMisc.cpp
+++ b/src/static/util/code/UtilMisc.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilMisc_ico.cpp
+++ b/src/static/util/code/UtilMisc_ico.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilMisc_sha1.cpp
+++ b/src/static/util/code/UtilMisc_sha1.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilOs.cpp
+++ b/src/static/util/code/UtilOs.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Casey Jones <jonescaseyb@gmail.com>
+          (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilOs_cmake.cpp.inc
+++ b/src/static/util/code/UtilOs_cmake.cpp.inc
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilString.cpp
+++ b/src/static/util/code/UtilString.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWeb.cpp
+++ b/src/static/util/code/UtilWeb.cpp
@@ -1,6 +1,8 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWindows.cpp
+++ b/src/static/util/code/UtilWindows.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Casey Jones <jonescaseyb@gmail.com>
+          (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWindows_dotnet.cpp
+++ b/src/static/util/code/UtilWindows_dotnet.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWindows_firewall.cpp
+++ b/src/static/util/code/UtilWindows_firewall.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWindows_osver.cpp
+++ b/src/static/util/code/UtilWindows_osver.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/UtilWindows_service.cpp
+++ b/src/static/util/code/UtilWindows_service.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/gcBuff.cpp
+++ b/src/static/util/code/gcBuff.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/gcDDE.cpp
+++ b/src/static/util/code/gcDDE.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/gcDDEManager.cpp
+++ b/src/static/util/code/gcDDEManager.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util/code/gcDDEManager.h
+++ b/src/static/util/code/gcDDEManager.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_bootloader/code/CreateProcess.cpp
+++ b/src/static/util_bootloader/code/CreateProcess.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_bootloader/code/UtilBootloader.cpp
+++ b/src/static/util_bootloader/code/UtilBootloader.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_bootloader/code/UtilMiscStub.cpp
+++ b/src/static/util_bootloader/code/UtilMiscStub.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_fs/code/UtilFs.cpp
+++ b/src/static/util_fs/code/UtilFs.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_fs/code/UtilFs_nix.cpp
+++ b/src/static/util_fs/code/UtilFs_nix.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_fs/code/UtilFs_win.cpp
+++ b/src/static/util_fs/code/UtilFs_win.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_thread/code/BaseThread.cpp
+++ b/src/static/util_thread/code/BaseThread.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_thread/code/ThreadPool.cpp
+++ b/src/static/util_thread/code/ThreadPool.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_thread/code/ThreadPoolThread.cpp
+++ b/src/static/util_thread/code/ThreadPoolThread.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/util_thread/code/ThreadPoolThread.h
+++ b/src/static/util_thread/code/ThreadPoolThread.h
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcButton.cpp
+++ b/src/static/wx_controls/code/gcButton.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCheckBox.cpp
+++ b/src/static/wx_controls/code/gcCheckBox.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcChoice.cpp
+++ b/src/static/wx_controls/code/gcChoice.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCombo.cpp
+++ b/src/static/wx_controls/code/gcCombo.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCustomFrameButtons.cpp
+++ b/src/static/wx_controls/code/gcCustomFrameButtons.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCustomFrameImpl.cpp
+++ b/src/static/wx_controls/code/gcCustomFrameImpl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCustomFrameMove.cpp
+++ b/src/static/wx_controls/code/gcCustomFrameMove.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCustomFrameResize.cpp
+++ b/src/static/wx_controls/code/gcCustomFrameResize.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcCustomMenu.cpp
+++ b/src/static/wx_controls/code/gcCustomMenu.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcDialog.cpp
+++ b/src/static/wx_controls/code/gcDialog.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcFrame.cpp
+++ b/src/static/wx_controls/code/gcFrame.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcGrid.cpp
+++ b/src/static/wx_controls/code/gcGrid.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcHyperlinkCtrl.cpp
+++ b/src/static/wx_controls/code/gcHyperlinkCtrl.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcImage.cpp
+++ b/src/static/wx_controls/code/gcImage.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcImageButton.cpp
+++ b/src/static/wx_controls/code/gcImageButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcImageControl.cpp
+++ b/src/static/wx_controls/code/gcImageControl.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcImageHandle.cpp
+++ b/src/static/wx_controls/code/gcImageHandle.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcImgButtonCount.cpp
+++ b/src/static/wx_controls/code/gcImgButtonCount.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcManagers.cpp
+++ b/src/static/wx_controls/code/gcManagers.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcMessageBox.cpp
+++ b/src/static/wx_controls/code/gcMessageBox.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcPanel.cpp
+++ b/src/static/wx_controls/code/gcPanel.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcProgressBar.cpp
+++ b/src/static/wx_controls/code/gcProgressBar.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcRadioButton.cpp
+++ b/src/static/wx_controls/code/gcRadioButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcScrolledWindow.cpp
+++ b/src/static/wx_controls/code/gcScrolledWindow.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcSpinnerProgBar.cpp
+++ b/src/static/wx_controls/code/gcSpinnerProgBar.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcSpinningBar.cpp
+++ b/src/static/wx_controls/code/gcSpinningBar.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcStaticLine.cpp
+++ b/src/static/wx_controls/code/gcStaticLine.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcStaticText.cpp
+++ b/src/static/wx_controls/code/gcStaticText.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcTaskBar.cpp
+++ b/src/static/wx_controls/code/gcTaskBar.cpp
@@ -1,6 +1,9 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Jookia <166291@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) Wojciech Zylinski <voitek@boskee.co.uk>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcTextCtrl.cpp
+++ b/src/static/wx_controls/code/gcTextCtrl.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcThemeManager.cpp
+++ b/src/static/wx_controls/code/gcThemeManager.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcThemeManager.h
+++ b/src/static/wx_controls/code/gcThemeManager.h
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcToggleButton.cpp
+++ b/src/static/wx_controls/code/gcToggleButton.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/gcUpProgBar.cpp
+++ b/src/static/wx_controls/code/gcUpProgBar.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
+          (C) Karol Herbst <git@karolherbst.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/static/wx_controls/code/guiDelegate.cpp
+++ b/src/static/wx_controls/code/guiDelegate.cpp
@@ -1,6 +1,6 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Desura Ltd. <support@desura.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/tests/helper_functions.h
+++ b/src/tests/helper_functions.h
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 template <typename T>
 bool isInVector(const T&, const std::vector<T>&);
 

--- a/src/tests/util/MD5_test.cpp
+++ b/src/tests/util/MD5_test.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MODULE MD5_test
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util/UtilLinux_test.cpp
+++ b/src/tests/util/UtilLinux_test.cpp
@@ -1,3 +1,23 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Karol Herbst <git@karolherbst.de>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util/gcBuff_test.cpp
+++ b/src/tests/util/gcBuff_test.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MODULE gcBuff_test
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util_fs/testFunctions.cpp
+++ b/src/tests/util_fs/testFunctions.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #ifndef TEST_DIR
 #error you have to define TEST_DIR first
 #endif

--- a/src/tests/util_fs/util_fs_copyFile.cpp
+++ b/src/tests/util_fs/util_fs_copyFile.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util_fs/util_fs_copyFolder.cpp
+++ b/src/tests/util_fs/util_fs_copyFolder.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util_fs/util_fs_getAllFiles.cpp
+++ b/src/tests/util_fs/util_fs_getAllFiles.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util_fs/util_fs_getAllFolders.cpp
+++ b/src/tests/util_fs/util_fs_getAllFolders.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tests/util_string/util_string_sanitizeFilePath.cpp
+++ b/src/tests/util_string/util_string_sanitizeFilePath.cpp
@@ -1,3 +1,21 @@
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Karol Herbst <git@karolherbst.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/src/tools/mcf_extract/code/main.cpp
+++ b/src/tools/mcf_extract/code/main.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2012 Jookia
+Copyright (C) Jookia <166291@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/tools/mcf_upload_cli/code/main.cpp
+++ b/src/tools/mcf_upload_cli/code/main.cpp
@@ -1,6 +1,7 @@
 /*
 Desura is the leading indie game distribution platform
-Copyright (C) 2011 Mark Chandler (Desura Net Pty Ltd)
+Copyright (C) Karol Herbst <git@karolherbst.de>
+          (C) matthiaskrgr <matthias.krueger@famsik.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/tools/mcf_util/code/CheckMCF.cpp
+++ b/src/tools/mcf_util/code/CheckMCF.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : CheckMCF.cpp
-//   Description :
-//      [TODO: Write the purpose of CheckMCF.cpp.]
-//
-//   Created On: 4/5/2011 4:20:02 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/CreateInstaller.cpp
+++ b/src/tools/mcf_util/code/CreateInstaller.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : CreateInstaller.cpp
-//   Description :
-//      [TODO: Write the purpose of CreateInstaller.cpp.]
-//
-//   Created On: 4/5/2011 4:21:42 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/CreateMCF.cpp
+++ b/src/tools/mcf_util/code/CreateMCF.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : CreateMCF.cpp
-//   Description :
-//      [TODO: Write the purpose of CreateMCF.cpp.]
-//
-//   Created On: 4/5/2011 4:13:28 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/MCFSetup.cpp
+++ b/src/tools/mcf_util/code/MCFSetup.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : MCFSetup.cpp
-//   Description :
-//      [TODO: Write the purpose of MCFSetup.cpp.]
-//
-//   Created On: 4/5/2011 4:28:07 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "SharedObjectLoader.h"

--- a/src/tools/mcf_util/code/PatchMCF.cpp
+++ b/src/tools/mcf_util/code/PatchMCF.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : PatchMCF.cpp
-//   Description :
-//      [TODO: Write the purpose of PatchMCF.cpp.]
-//
-//   Created On: 4/5/2011 4:57:30 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/SaveMCF.cpp
+++ b/src/tools/mcf_util/code/SaveMCF.cpp
@@ -1,13 +1,21 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : SaveMCF.cpp
-//   Description :
-//      [TODO: Write the purpose of SaveMCF.cpp.]
-//
-//   Created On: 4/5/2011 4:08:21 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Ian T. Jacobsen <iantj92@gmail.com>
+          (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/TestMCF.cpp
+++ b/src/tools/mcf_util/code/TestMCF.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : TestMCF.cpp
-//   Description :
-//      [TODO: Write the purpose of TestMCF.cpp.]
-//
-//   Created On: 4/5/2011 4:21:08 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/UtilFunction.cpp
+++ b/src/tools/mcf_util/code/UtilFunction.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : UtilFunction.cpp
-//   Description :
-//      [TODO: Write the purpose of UtilFunction.cpp.]
-//
-//   Created On: 4/5/2011 4:14:17 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/src/tools/mcf_util/code/UtilFunction.h
+++ b/src/tools/mcf_util/code/UtilFunction.h
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : UtilFunction.h
-//   Description :
-//      [TODO: Write the purpose of UtilFunction.h.]
-//
-//   Created On: 4/5/2011 4:05:02 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #ifndef DESURA_UTILFUNCTION_H
 #define DESURA_UTILFUNCTION_H

--- a/src/tools/mcf_util/code/main.cpp
+++ b/src/tools/mcf_util/code/main.cpp
@@ -1,13 +1,20 @@
-///////////// Copyright © 2010 DesuraNet. All rights reserved. /////////////
-//
-//   Project     : mcf_util
-//   File        : main.cpp
-//   Description :
-//      [TODO: Write the purpose of main.cpp.]
-//
-//   Created On: 4/5/2011 4:30:23 PM
-//   Created By:  <mailto:>
-////////////////////////////////////////////////////////////////////////////
+/*
+Desura is the leading indie game distribution platform
+Copyright (C) Mark Chandler <mark@moddb.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
 
 #include "Common.h"
 #include "UtilFunction.h"

--- a/third_party/npwrapper/src/wrapper/npw-wrapper.c
+++ b/third_party/npwrapper/src/wrapper/npw-wrapper.c
@@ -3,6 +3,7 @@
  *
  *  nspluginwrapper (C) 2005-2009 Gwenole Beauchesne
  *                  (C) 2011 David Benjamin
+ *                  (C) 2013 Karol Herbst <git@karolherbst.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
fixes #543

I wrote a script, which is handles all html, js, css, h, C++ and C files.

RC files were generated by msvc, but maybe we should clean them up and add the rc pattern to this script, too.

This script also added newlines at the end of every file without an empty new line. On Linux we should have empty lines at the end anyway.
