### PR TITLE
cmake/v8: fix v8 build on windows

### DIFF
--- a/cmake/modules/Buildv8.cmake
+++ b/cmake/modules/Buildv8.cmake
@@ -11,6 +11,9 @@ if(UNIX)
   set(V8_CONFIGURE_CMD ${CMAKE_SCRIPT_PATH}/depot_tools_wrapper.sh <SOURCE_DIR>/build gyp_v8 -Dcomponent=shared_library -Dwerror= --generator-output=out -f make ${EXTRA_OPTS})
   set(V8_BUILD_CMD $(MAKE) $ENV{MAKEOPTS} V=1 -C out BUILDTYPE=Release CC.host=${CMAKE_C_COMPILER} CXX.host=${CMAKE_CXX_COMPILER} LINK.host=${CMAKE_CXX_COMPILER} AR.host=${CMAKE_AR})
 else()
+  if(NOT SUBVERSION_FOUND)
+    find_package(Subversion REQUIRED)
+  endif()
   set(V8_CONFIGURE_CMD ${PYTHON_EXECUTABLE} <SOURCE_DIR>/build/gyp_v8 -Dcomponent=shared_library -f msvs -Dtarget_arch=ia32)
   if(DEBUG_V8)
     set(V8_BUILD_CMD msbuild <SOURCE_DIR>/tools/gyp/v8.sln /m /p:Platform=Win32 /p:Configuration=Debug)
@@ -35,6 +38,7 @@ ExternalProject_Add_Step(
   cygwin-svn-fetch
   COMMAND ${Subversion_SVN_EXECUTABLE} co http://src.chromium.org/svn/trunk/deps/third_party/cygwin@66844 third_party/cygwin
   DEPENDERS configure
+  DEPENDEES download
   WORKING_DIRECTORY <SOURCE_DIR>
 )
 endif()


### PR DESCRIPTION
This commits fixes 2 issues:
1. If cmake is download the v8 archive, the cygwin checkout happens before
2. If CEF isn't building, cmake won't search for SVN
