### PR TITLE
Use Wx3.0 instead of bundled 2.9.3 if present in the system.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - mkdir build
   - cd build
 script:
-  - cmake .. -DBUILD_CEF=off -DWITH_ARES=off -DDEBUG=on -DFORCE_BUNDLED_WXGTK=off
+  - cmake .. -DBUILD_CEF=off -DWITH_ARES=off -DDEBUG=on
   - make -j4
   - ctest --output-on-failure .
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 #   CURL_URL                            URL to curl archive
 #   DEPOT_TOOLS_URL                     URL to depot_tools archive
 #   V8_URL                              URL to v8 archive
-#   WXWIDGET_URL                        URL to wxWidget archive, has to be 2.9.3
+#   WXWIDGET_URL                        URL to wxWidget archive, has to be 3.0
 #
 # cef options:
 #   H264_SUPPORT    OFF                 build ffmpeg with mpeg-4 support. Be aware of patent and license problems
@@ -36,8 +36,8 @@
 #   DESKTOPDIR      depends on OS       the directory where the desktop file or link should be installed
 #
 # unix-only options:
-#   FORCE_BUNDLED_WXGTK  		OFF: bundle wxGTK 2.9.3
-#                   ON			OFF: use system wxGTK (has to be 3.0 or later)
+#   FORCE_BUNDLED_WXGTK                 OFF: use system wxGTK (has to be 3.0 or later)
+#                   OFF	                ON: bundle wxGTK 3.0.0-r1
 #   DEBUG_EXTERNAL  OFF                 same as DEBUG, but for externap deps
 #   WITH_ARES       ON                  build CURL with ares support (c-ares REQUIRED)
 #   DIR_TYPE        SINGLE              how should game data be stored?
@@ -52,8 +52,8 @@
 #   DESKTOP_ICON    desura              the value of Icon in the desktop file
 #
 # wxWidgets select optional  version
-#   wxWidgets_CONFIG_EXECUTABLE         path to wx-config (version 2.9.x or later)
-#   wxWidgets_wxrc_EXECUTABLE           path to wxrc (version 2.9.x or later)
+#   wxWidgets_CONFIG_EXECUTABLE         path to wx-config (version 3.0.x or later)
+#   wxWidgets_wxrc_EXECUTABLE           path to wxrc (version 3.0.x or later)
 #
 # windows-only options:
 #   BOOST_URL                           URL to boost archive
@@ -286,11 +286,11 @@ else()
   unset(V8_MD5)
 endif()
 
-set(WXWIDGET_URL_DEFAULT http://garr.dl.sourceforge.net/project/wxwindows/2.9.3/wxWidgets-2.9.3.tar.bz2)
+set(WXWIDGET_URL_DEFAULT http://garr.dl.sourceforge.net/project/wxwindows/3.0.0-rc1/wxWidgets-3.0.0-rc1.tar.bz2)
 set(WXWIDGET_URL ${WXWIDGET_URL_DEFAULT}
-    CACHE STRING "URL to wxWidget 2.9.3 archive")
+    CACHE STRING "URL to wxWidget 3.0.0-r1 archive")
 if(WXWIDGET_URL STREQUAL WXWIDGET_URL_DEFAULT)
-  set(WXWIDGET_MD5 6b6003713289ea4d3cd9b49c5db5b721)
+  set(WXWIDGET_MD5 a4f74ef439b7a95d76c699b3a198097c)
 else()
   unset(WXWIDGET_MD5)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@
 #   DESKTOPDIR      depends on OS       the directory where the desktop file or link should be installed
 #
 # unix-only options:
-#   FORCE_BUNDLED_WXGTK  		ON: bundle wxGTK 2.9.3
-#                   ON			OFF: use system wxGTK (has to be 2.9.x, work stable on 2.9.3)
+#   FORCE_BUNDLED_WXGTK  		OFF: bundle wxGTK 2.9.3
+#                   ON			OFF: use system wxGTK (has to be 3.0 or later)
 #   DEBUG_EXTERNAL  OFF                 same as DEBUG, but for externap deps
 #   WITH_ARES       ON                  build CURL with ares support (c-ares REQUIRED)
 #   DIR_TYPE        SINGLE              how should game data be stored?
@@ -51,9 +51,9 @@
 #   DESKTOP_EXE     desura              the value of Exe in the desktop file
 #   DESKTOP_ICON    desura              the value of Icon in the desktop file
 #
-# wxWidgets select correct  version
-#   wxWidgets_CONFIG_EXECUTABLE         path to wx-config (version 2.9.x)
-#   wxWidgets_wxrc_EXECUTABLE           path to wxrc (version 2.9.x)
+# wxWidgets select optional  version
+#   wxWidgets_CONFIG_EXECUTABLE         path to wx-config (version 2.9.x or later)
+#   wxWidgets_wxrc_EXECUTABLE           path to wxrc (version 2.9.x or later)
 #
 # windows-only options:
 #   BOOST_URL                           URL to boost archive
@@ -187,7 +187,7 @@ if(NOT BUILD_ONLY_CEF)
   find_package(v8 ${REQUIRED_IF_OPTION})
 
   if(NOT FORCE_BUNDLED_WXGTK)
-    find_package(wxWidgets 2.9 COMPONENTS richtext ${REQUIRED_IF_OPTION})
+    find_package(wxWidgets 3.0 COMPONENTS richtext ${REQUIRED_IF_OPTION})
   endif()
 endif()
 

--- a/cmake/modules/BuildwxWidgets.cmake
+++ b/cmake/modules/BuildwxWidgets.cmake
@@ -1,6 +1,6 @@
 if(WIN32 AND NOT MINGW)
   ExternalProject_Add(
-    wxWidget-2-9
+    wxWidget-3-0
     URL ${WXWIDGET_URL}
     URL_MD5 ${WXWIDGET_MD5}
     UPDATE_COMMAND ""
@@ -14,7 +14,7 @@ if(WIN32 AND NOT MINGW)
   
   if(DEBUG) 
     ExternalProject_Add_Step(
-      wxWidget-2-9
+      wxWidget-3-0
       custom_build
       DEPENDEES configure
       DEPENDERS build
@@ -23,7 +23,7 @@ if(WIN32 AND NOT MINGW)
     )
   else()
     ExternalProject_Add_Step(
-      wxWidget-2-9
+      wxWidget-3-0
       custom_build
       DEPENDEES configure
       DEPENDERS build
@@ -33,7 +33,7 @@ if(WIN32 AND NOT MINGW)
   endif()
   
   ExternalProject_Get_Property(
-    wxWidget-2-9
+    wxWidget-3-0
     source_dir
   )
   set(wxWidgets_INSTALL_DIR ${source_dir})
@@ -54,14 +54,14 @@ if(WIN32 AND NOT MINGW)
   
 else()
   if(MINGW)
-    set(WX_SETUP_INCLUDE_SUB "msw-unicode-2.9-desura")
-    set(WX_SETUP_INCLUDE_SUB_DEBUG "msw-unicode-debug-2.9-desura")
-	set(WX_LIB_NAME "libwx_mswu_desura-2.9.dll.a")
-	set(WX_LIB_NAME_DEBUG "libwx_mswu_desura-2.9.dll.a")
+    set(WX_SETUP_INCLUDE_SUB "msw-unicode-3.0-desura")
+    set(WX_SETUP_INCLUDE_SUB_DEBUG "msw-unicode-debug-3.0-desura")
+	set(WX_LIB_NAME "libwx_mswu_desura-3.0.dll.a")
+	set(WX_LIB_NAME_DEBUG "libwx_mswu_desura-3.0.dll.a")
   else()
-    set(WX_SETUP_INCLUDE_SUB "gtk2-unicode-2.9-desura")
+    set(WX_SETUP_INCLUDE_SUB "gtk2-unicode-3.0-desura")
     set(WX_SETUP_INCLUDE_SUB_DEBUG ${WX_SETUP_INCLUDE_SUB})
-	set(WX_LIB_NAME "libwx_gtk2u_desura-2.9.so.3.0.0")
+	set(WX_LIB_NAME "libwx_gtk2u_desura-3.0.so.0.0.0")
 	set(WX_LIB_NAME_DEBUG ${WX_LIB_NAME})
   endif()
 
@@ -72,34 +72,77 @@ else()
   endif()
 
   ExternalProject_Add(
-    wxWidget-2-9
+    wxWidget-3-0
     URL ${WXWIDGET_URL}
     URL_MD5 ${WXWIDGET_MD5}
     UPDATE_COMMAND ""
     ${WX_PATCH_COMMAND}
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ./configure
-        --enable-shared --enable-unicode ${CONFIGURE_DEBUG}
-        --enable-monolithic --with-flavour=desura --enable-threads --with-opengl=no --disable-palette
-        --disable-joystick --disable-mediactrl --prefix=${wxWidgets_INSTALL_DIR} --enable-permissive
+    CONFIGURE_COMMAND ./configure --disable-all-features
+        --enable-animatectrl 
+        --enable-button
+        --enable-checkbox
+        --enable-choice
+        --enable-clipboard
+        --enable-combobox
+        --enable-dataobj
+        --enable-datetime
+        --enable-dirdlg
+        --enable-exceptions
+        --enable-file
+        --enable-filectrl
+        --enable-filedlg
+        --enable-filepicker
+        --enable-fontmap
+        --enable-grid
+        --enable-headerctrl
+        --enable-hyperlink
+        --enable-image
+        --with-libpng
+        --enable-imaglist
+        --enable-intl
+        --enable-listctrl
+        --enable-log
+        --enable-longlong
+        --enable-menus
+        --enable-msgdlg
+        --with-opengl=no
+        --enable-radiobtn
+        --enable-snglinst
+        --enable-stattext
+        --enable-streams
+        --enable-taskbaricon
+        --enable-textctrl
+        --enable-timer
+        --enable-tooltips
+        --enable-treectrl
+        --enable-validators
+        --enable-shared
+        --enable-unicode
+        ${CONFIGURE_DEBUG}
+        --enable-monolithic
+        --with-flavour=desura
+        --enable-threads
+        --prefix=${wxWidgets_INSTALL_DIR}
+        --enable-permissive
   )
   
   set(wxWidgets_LIBRARY_DIRS ${wxWidgets_INSTALL_DIR}/lib)
   if(DEBUG_EXTERNAL)
-    set(wxWidgets_INCLUDE_DIRS  ${wxWidgets_INSTALL_DIR}/include/wx-2.9-desura ${wxWidgets_LIBRARY_DIRS}/wx/include/${WX_SETUP_INCLUDE_SUB_DEBUG})
+    set(wxWidgets_INCLUDE_DIRS  ${wxWidgets_INSTALL_DIR}/include/wx-3.0-desura ${wxWidgets_LIBRARY_DIRS}/wx/include/${WX_SETUP_INCLUDE_SUB_DEBUG})
     set(wxWidgets_LIBRARIES "${wxWidgets_LIBRARY_DIRS}/${WX_LIB_NAME_DEBUG}")
     install(FILES ${wxWidgets_LIBRARY_DIRS}/${WX_LIB_NAME}
-            RENAME libwx_gtk2u_desura-2.9.so.3
+            RENAME libwx_gtk2u_desura-3.0.so.0
             DESTINATION ${LIB_INSTALL_DIR})
   else()
-    set(wxWidgets_INCLUDE_DIRS  ${wxWidgets_INSTALL_DIR}/include/wx-2.9-desura ${wxWidgets_LIBRARY_DIRS}/wx/include/${WX_SETUP_INCLUDE_SUB})
+    set(wxWidgets_INCLUDE_DIRS  ${wxWidgets_INSTALL_DIR}/include/wx-3.0-desura ${wxWidgets_LIBRARY_DIRS}/wx/include/${WX_SETUP_INCLUDE_SUB})
     set(wxWidgets_LIBRARIES "${wxWidgets_LIBRARY_DIRS}/${WX_LIB_NAME}")
     install(FILES ${wxWidgets_LIBRARY_DIRS}/${WX_LIB_NAME}
-            RENAME libwx_gtk2u_desura-2.9.so.3
+            RENAME libwx_gtk2u_desura-3.0.so.0
             DESTINATION ${LIB_INSTALL_DIR})
   endif()
   set(wxWidgets_BIN_DIR ${wxWidgets_INSTALL_DIR}/bin)
   set(wxWidgets_CONFIG_EXECUTABLE ${wxWidgets_BIN_DIR}/wx-config)
 endif()
 
-SET_PROPERTY(TARGET wxWidget-2-9                PROPERTY FOLDER "ThirdParty")
+SET_PROPERTY(TARGET wxWidget-3-0                PROPERTY FOLDER "ThirdParty")

--- a/cmake/modules/CheckOptions.cmake
+++ b/cmake/modules/CheckOptions.cmake
@@ -39,7 +39,7 @@ if(NOT BUILD_ONLY_CEF)
     option(WITH_ARES "build cURL with c-ares support" ON)
     option(DEBUG_EXTERNAL "build external libs with debug support" OFF)
     option(INSTALL_DESKTOP_FILE "install the generated desktop file to /usr/share/applications/" OFF)
-    option(FORCE_BUNDLED_WXGTK "force building of bundled wxGTK" ON)
+    option(FORCE_BUNDLED_WXGTK "force building of bundled wxGTK" OFF)
   endif()
 
   ###############################################################################

--- a/src/shared/uicore/code/UICoreMain.cpp
+++ b/src/shared/uicore/code/UICoreMain.cpp
@@ -220,13 +220,6 @@ public:
 		Warning(gcString("wx Assert: {0}\n", msg.mb_str()));
 		return true;
 	}
-	
-#if not wxCHECK_VERSION(2,9,5) //wxAppTraits::SetLocale() is replaced by wxApp::SetCLocale()
-	virtual void SetLocale()
-	{
-		m_pOldTraits->SetLocale();
-	}
-#endif
 
 	virtual wxLog* CreateLogTarget()
 	{

--- a/src/shared/uicore/code/UICoreMain.cpp
+++ b/src/shared/uicore/code/UICoreMain.cpp
@@ -221,11 +221,13 @@ public:
 		return true;
 	}
 	
+#if not wxCHECK_VERSION(2,9,5) //wxAppTraits::SetLocale() is replaced by wxApp::SetCLocale()
 	virtual void SetLocale()
 	{
 		m_pOldTraits->SetLocale();
 	}
-	
+#endif
+
 	virtual wxLog* CreateLogTarget()
 	{
 		return m_pOldTraits->CreateLogTarget();
@@ -553,5 +555,3 @@ CONCOMMAND(exitApp, "exit")
 	if (g_pMainApp)
 		g_pMainApp->Close();
 }
-
-

--- a/src/static/wx_controls/code/gcImageControl.cpp
+++ b/src/static/wx_controls/code/gcImageControl.cpp
@@ -261,8 +261,12 @@ bool SetShape(const wxRegion& region, wxWindow* frame)
 	{	
 		wxBitmap bmp = ConvertRegionToBitmap(region);
 		bmp.SetMask(new wxMask(bmp, *wxBLACK));
-		
+
+#if wxCHECK_VERSION(2,9,5)
+		GdkBitmap* mask = *bmp.GetMask();
+#else
 		GdkBitmap* mask = bmp.GetMask()->GetBitmap();
+#endif
 
 		if (m_wxwindow)
 			gtk_widget_shape_combine_mask(m_wxwindow, mask, 0, 0);

--- a/src/static/wx_controls/code/gcImageControl.cpp
+++ b/src/static/wx_controls/code/gcImageControl.cpp
@@ -262,11 +262,7 @@ bool SetShape(const wxRegion& region, wxWindow* frame)
 		wxBitmap bmp = ConvertRegionToBitmap(region);
 		bmp.SetMask(new wxMask(bmp, *wxBLACK));
 
-#if wxCHECK_VERSION(2,9,5)
 		GdkBitmap* mask = *bmp.GetMask();
-#else
-		GdkBitmap* mask = bmp.GetMask()->GetBitmap();
-#endif
 
 		if (m_wxwindow)
 			gtk_widget_shape_combine_mask(m_wxwindow, mask, 0, 0);


### PR DESCRIPTION
wxWidgets developers manage to point out fixes for the breaks in compatibility with wxWidgets 2.9.5.
http://trac.wxwidgets.org/ticket/15529

With this pull request if wxWidgets 3.0 is present in the system, than it will be used instead of bundled 2.9.3. On Linux it works great on wxWidgets 3.0.0-r1 without pink dots regression: #288 and still provide backward compatibility with wxWidgets 2.9.3.

I publish this pull request for testing purposes. I hope that when wxWidgets 3.0 comes out it will be working great with this changes and then we can merge it to the master.
