### PR TITLE
travis: build with clang and gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 compiler: gcc
 before_install:
   - sudo apt-get update
-  - sudo apt-get install gcc-multilib libnotify-dev libv8-dev libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-thread-dev libboost-system-dev libboost-test-dev
+  - sudo apt-get install gcc-multilib libnotify-dev libv8-dev libboost1.48-dev libboost-date-time1.48-dev libboost-filesystem1.48-dev libboost-thread1.48-dev libboost-system1.48-dev libboost-test1.48-dev
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-dev_2.9.3-1_amd64.deb"
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/wx2.9-headers_2.9.3-1_amd64.deb"
   - wget "http://ppa.launchpad.net/fransschreuder1/usbpicprog-stable/ubuntu/pool/main/w/wxwidgets2.9/libwxgtk2.9-0_2.9.3-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
-compiler: gcc
+compiler:
+  - gcc
+  - clang
 before_install:
   - sudo apt-get update
   - sudo apt-get install gcc-multilib libnotify-dev libv8-dev libboost1.48-dev libboost-date-time1.48-dev libboost-filesystem1.48-dev libboost-thread1.48-dev libboost-system1.48-dev libboost-test1.48-dev

--- a/src/executable/bootloader_lin/code/DesuraMain.cpp
+++ b/src/executable/bootloader_lin/code/DesuraMain.cpp
@@ -301,7 +301,7 @@ bool MainApp::onCrash(const char* path)
 	if (!path)
 	{
 		fprintf(stderr, "on crash path is null!");
-		return;
+		return false;
 	}
 	else
 	{


### PR DESCRIPTION
this just bumps the boost version on travis to 1.48, fixes a simple clang error and activate building with gcc and clang on travis-ci
