### PR TITLE
Fix fork license to LGPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Update
 ==================
 
-Desurium has been forked and relicensed under Gpl v2.1 and thus is currently not being actively developed by Desura or Lindenlab. This repository has been left under the Gpl v3 license and is still free to be used by all under the terms of the license.
+Desurium has been forked and relicensed under LGPL v2.1 and thus is currently not being actively developed by Desura or Lindenlab. This repository has been left under the Gpl v3 license and is still free to be used by all under the terms of the license.
 
 Please see the new repository/wiki/issues at https://github.com/lindenlab/desura-app for future continuation of Desura
 


### PR DESCRIPTION
 lodle make a typo. New fork license is LGPL, not GPL. This might be very misleading, so should be fixed.
