### PR TITLE
use defaults for tinyxml2 parse

### DIFF
--- a/src/tools/mcf_util/code/UploadMCF.cpp
+++ b/src/tools/mcf_util/code/UploadMCF.cpp
@@ -400,7 +400,7 @@ public:
 		printf("%s\n", std::string(wc->getData(), wc->getDataSize()).c_str());
 
 		tinyxml2::XMLDocument doc;
-		doc.Parse(const_cast<char*>(wc->getData()), wc->getDataSize());
+		doc.Parse(const_cast<char*>(wc->getData()));
 
 		try
 		{


### PR DESCRIPTION
fix #716
